### PR TITLE
Add initial README with architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,85 @@
-# Aurora SAC
+# Faladesk
 
-Aurora SAC is an open-source, multi-tenant customer support platform for
-Brazilian and Latin American businesses. It provides realtime chat, ticketing
-and AI-assisted agents powered by Supabase, React and TypeScript.
+Faladesk is an open-source, multi-tenant SaaS platform for customer support (SAC) tailored for Brazil and Latin America. It integrates chat and ticket management across popular channels and provides AI-powered agents that can automatically resolve customer queries.
 
-**Key Features**
+## Project Summary
 
-- Magic link authentication with organizations/teams per tenant
-- Realtime chat and ticketing with channel adapters
-- AI agent hand‑off to human agents
-- Workflow automations and customer portal
+**Purpose:** Provide businesses with a single platform to handle customer support from WhatsApp, email, and other channels while using AI to automate replies or escalate to human agents.
 
-This repository contains a minimal reference implementation. All code is
-released under the Business Source License 1.1 (see `LICENSE`).
+**Audience:** Small and medium businesses or integrators who need an extensible SAC platform.
+
+**Technologies:** Built with [Supabase](https://supabase.com/) for authentication and realtime data, a React frontend (using Gluestack UI), and optional Kubernetes deployment.
+
+## Key Features
+
+- Multi-tenant organizations with role-based access (admin, agent)
+- Conversational support with tickets stored in Supabase
+- Channel adapters for WhatsApp (Twilio, 360Dialog) and Email
+- MCP agents using OpenAI for automated support
+- Realtime syncing with Supabase subscriptions
+- Optional customer portal for viewing ticket history
+- Custom workflow rules (e.g., auto-response, escalation triggers)
+- Designed for Kubernetes deployment
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Channels
+        WA["WhatsApp"]
+        Email["Email"]
+    end
+
+    subgraph "Channel Adapter Services"
+        WA --> Adapters
+        Email --> Adapters
+    end
+
+    subgraph Supabase
+        DB[("DB / Auth / Edge Functions")]
+    end
+
+    subgraph "MCP Agent"
+        LLMRouter["LLM Router"]
+    end
+
+    subgraph "Frontend"
+        AgentConsole["Agent Console"]
+        CustomerPortal["Customer Portal"]
+    end
+
+    Adapters --"HTTP/Webhook"--> DB
+    Adapters --> LLMRouter
+    LLMRouter --> DB
+
+    AgentConsole --"Realtime"--> DB
+    CustomerPortal --"Realtime"--> DB
+
+    subgraph "Pub/Sub"
+        Pubsub["Supabase Subs / Redis"]
+    end
+
+    DB <--> Pubsub
+    Pubsub --> AgentConsole
+    Pubsub --> CustomerPortal
+
+    subgraph Optional
+        WorkflowEngine["Workflow Engine"]
+    end
+
+    WorkflowEngine -.-> DB
+```
+```
+
+## Folder Structure
+
+- [`/apps/frontend`](./apps/frontend) – React interface for agents and customers
+- [`/supabase`](./supabase) – Edge functions and SQL migrations
+- [`/functions`](./functions) – Channel adapter webhooks (e.g., WhatsApp, Email)
+- [`/docs`](./docs) – Diagrams and documentation
+- [`/k8s`](./k8s) – Kubernetes manifests
+- [`/docker`](./docker) – Dockerfiles and Compose configuration
+
+## License
+
+Faladesk is released under the Business Source License 1.1. It is free for personal or internal business use. Commercial resale or providing it as a service requires a separate license. See [`LICENSE`](./LICENSE) for details.


### PR DESCRIPTION
## Summary
- describe Faladesk customer support SaaS
- outline key features
- show architecture using a mermaid diagram
- document folder layout and license

## Testing
- `git status --short`