### PR TITLE
Align database schema with design

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,29 +1,40 @@
 -- Organization and user management
 create table if not exists organizations (
   id uuid primary key default gen_random_uuid(),
-  name text not null
+  name text not null,
+  slug text unique not null,
+  created_at timestamptz default now()
 );
 
-create table if not exists memberships (
-  user_id uuid references auth.users on delete cascade,
+
+create table if not exists users (
+  id uuid primary key references auth.users on delete cascade,
+  email text not null,
+  name text,
+  avatar_url text,
   organization_id uuid references organizations on delete cascade,
-  primary key (user_id, organization_id)
+  role text not null check (role in ('admin','agent')),
+  created_at timestamptz default now()
 );
 
 -- Conversations and messages
 create table if not exists conversations (
   id uuid primary key default gen_random_uuid(),
   organization_id uuid references organizations,
+  customer_name text,
   channel text not null, -- e.g. whatsapp, email
   status text not null default 'open',
-  created_at timestamptz default now()
+  assigned_user_id uuid references users,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
 );
 
 create table if not exists messages (
   id uuid primary key default gen_random_uuid(),
   conversation_id uuid references conversations on delete cascade,
-  sender text not null, -- 'customer' or 'agent'
+  sender text not null check (sender in ('user','customer','agent','ai')),
   content text,
+  metadata jsonb,
   created_at timestamptz default now()
 );
 
@@ -32,7 +43,9 @@ create table if not exists workflows (
   id uuid primary key default gen_random_uuid(),
   organization_id uuid references organizations,
   name text not null,
-  trigger jsonb, -- conditions for activation
-  action jsonb   -- action to perform
+  trigger_type text not null,
+  conditions jsonb,
+  actions jsonb,
+  is_active boolean not null default true
 );
 


### PR DESCRIPTION
## Summary
- extend organizations with slug and created_at
- add users table referencing `auth.users`
- track assignee, timestamps, and customer name for conversations
- support metadata on messages and more sender types
- expand workflows with type, conditions, actions, and active flag

## Testing
- `npm test` *(fails: Could not find package.json)*