### PR TITLE
Add standard Node/Deno gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node dependencies
+node_modules/
+
+# Build outputs
+/dist/
+/build/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.*
+*.env
+
+# Misc
+.DS_Store
+


### PR DESCRIPTION
## Summary
- ignore Node modules and build outputs
- ignore environment files and logs

## Testing
- `deno --version` *(fails: command not found)*