### PR TITLE
Add testing scaffolding

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=anon-test-key
+SUPABASE_URL=http://localhost:54321
+SUPABASE_SERVICE_ROLE_KEY=service-role-test-key
+OPENAI_API_KEY=test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install frontend deps
+        run: |
+          cd web
+          npm install
+      - name: Run frontend tests
+        run: |
+          cd web
+          npm run test -- --run
+      - name: Run edge function tests
+        run: |
+          cd supabase/functions
+          deno test -A

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ yarn-error.log*
 .env.*
 *.env
 !.env.example
+!.env.test
 
 # Misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ supabase functions deploy message-handler
 
 Ensure your Supabase URL and keys are configured in your environment before deploying.
 
+## Testing
+
+Vitest is used for frontend unit and integration tests located in `apps/frontend/tests`. Deno's built-in `deno test` runs the edge function tests under `supabase/functions/tests`.
+
+Run all tests:
+
+```bash
+# Frontend
+cd web && npm install
+npm run test
+
+# Edge functions
+cd ../supabase/functions
+deno test -A
+```
+
 ## License
 
 Faladesk is released under the Business Source License 1.1. It is free for personal or internal business use. Commercial resale or providing it as a service requires a separate license. See [`LICENSE`](./LICENSE) for details.

--- a/apps/frontend/tests/components/ConversationList.test.tsx
+++ b/apps/frontend/tests/components/ConversationList.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('ConversationList', () => {
+  test.todo('renders conversations correctly')
+})

--- a/apps/frontend/tests/components/MessageBubble.test.tsx
+++ b/apps/frontend/tests/components/MessageBubble.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('MessageBubble', () => {
+  test.todo('differentiates sender roles')
+})

--- a/apps/frontend/tests/components/ReplyBox.test.tsx
+++ b/apps/frontend/tests/components/ReplyBox.test.tsx
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('ReplyBox', () => {
+  test.todo('calls sendMessage function and clears input')
+})

--- a/apps/frontend/tests/e2e/conversation-flow.spec.ts
+++ b/apps/frontend/tests/e2e/conversation-flow.spec.ts
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('Conversation flow', () => {
+  test.todo('open conversation and reply')
+})

--- a/apps/frontend/tests/e2e/login.spec.ts
+++ b/apps/frontend/tests/e2e/login.spec.ts
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('Login flow', () => {
+  test.todo('user can login and view inbox')
+})

--- a/apps/frontend/tests/utils/supabaseHooks.test.ts
+++ b/apps/frontend/tests/utils/supabaseHooks.test.ts
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('Supabase hooks', () => {
+  test.todo('mock API call logic')
+})

--- a/supabase/functions/test-utils/mockMessages.ts
+++ b/supabase/functions/test-utils/mockMessages.ts
@@ -1,0 +1,5 @@
+export const sampleMessage = {
+  customer_name: 'Tester',
+  channel: 'whatsapp',
+  content: 'hello'
+}

--- a/supabase/functions/test-utils/mockSupabaseClient.ts
+++ b/supabase/functions/test-utils/mockSupabaseClient.ts
@@ -1,0 +1,8 @@
+export function createMockClient() {
+  return {
+    from: () => ({
+      insert: () => ({ select: () => Promise.resolve({ data: {} }) }),
+      select: () => ({ single: () => Promise.resolve({ data: {} }) })
+    })
+  }
+}

--- a/supabase/functions/tests/receive-message.test.ts
+++ b/supabase/functions/tests/receive-message.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
+
+Deno.test('receive-message saves message to DB', async () => {
+  // TODO: mock Supabase client
+  assertEquals(true, true)
+})

--- a/supabase/functions/tests/route-to-ai.test.ts
+++ b/supabase/functions/tests/route-to-ai.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
+
+Deno.test('route-to-ai returns structured reply', async () => {
+  // TODO: mock OpenAI call
+  assertEquals(true, true)
+})

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@gluestack-ui/themed": "^0.1.0",
@@ -22,6 +23,10 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.1.3",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "vitest": "^0.34.0",
+    "jsdom": "^22.1.0"
   }
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
+})

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- add vitest config and test script for the React app
- provide basic test skeletons for frontend components
- create Deno test scaffolds for edge functions
- add GitHub Actions workflow to run tests
- document how to run tests in README
- store sample `.env.test` for running tests

## Testing
- `npm install` *(fails: ENOENT due to no network)*
- `npm test -- --run` *(fails: vitest not found because deps not installed)*
- `deno test -A` *(fails: command not found)*