### PR TITLE
Add MCP route-to-ai edge function

### DIFF
--- a/supabase/functions/route-to-ai.ts
+++ b/supabase/functions/route-to-ai.ts
@@ -1,13 +1,35 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-serve(async (req) => {
-  const { conversation_id, message_id, organization_id } = await req.json()
+interface Payload {
+  conversation_id: string
+  message_id?: string
+  organization_id?: string
+}
 
-  const supabase = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  )
+interface HandleResult {
+  acted: boolean
+  reply?: string
+}
+
+export async function handleRouteToAI(
+  payload: Payload,
+  opts: { supabase?: any; fetcher?: typeof fetch } = {}
+): Promise<HandleResult> {
+  const supabase =
+    opts.supabase ??
+    createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+  const doFetch = opts.fetcher ?? fetch
+
+  const { conversation_id, organization_id } = payload
+
+  // verify payload
+  if (!conversation_id) {
+    throw new Error('invalid payload')
+  }
 
   // check conversation assignment
   const { data: convo } = await supabase
@@ -17,17 +39,19 @@ serve(async (req) => {
     .single()
 
   if (!convo) {
-    return new Response(
-      JSON.stringify({ error: 'conversation not found' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    )
+    throw new Error('conversation not found')
   }
 
   if (convo.assigned_user_id) {
-    return new Response(
-      JSON.stringify({ ok: true, skipped: true }),
-      { headers: { 'Content-Type': 'application/json' } }
-    )
+    const { data: user } = await supabase
+      .from('users')
+      .select('name')
+      .eq('id', convo.assigned_user_id)
+      .single()
+    const aiName = Deno.env.get('DEFAULT_AGENT_NAME') ?? 'Falabot'
+    if (!user || user.name !== aiName) {
+      return { acted: false }
+    }
   }
 
   // fetch last messages for context
@@ -38,37 +62,41 @@ serve(async (req) => {
     .order('created_at', { ascending: false })
     .limit(10)
 
-  const context = (history ?? []).reverse().map((m) => ({
-    role: m.sender === 'customer' ? 'user' : 'assistant',
-    content: m.content ?? ''
-  }))
+  const context = (history ?? [])
+    .reverse()
+    .map((m: any) => ({
+      role: m.sender === 'customer' ? 'user' : 'assistant',
+      content: m.content ?? ''
+    }))
 
   // organization tone if defined
-  let systemPrompt = 'You are an AI support agent.'
+  let tone = 'friendly'
   if (organization_id) {
     const { data: org } = await supabase
       .from('organizations')
-      .select('tone')
+      .select('metadata')
       .eq('id', organization_id)
       .single()
-    if (org?.tone) {
-      systemPrompt = `Respond in a ${org.tone} tone.`
+    if (org?.metadata?.tone) {
+      tone = org.metadata.tone
     }
   }
+  const aiName = Deno.env.get('DEFAULT_AGENT_NAME') ?? 'Falabot'
+  const systemPrompt = `You are ${aiName}, an AI support agent. Respond in a ${tone} tone.`
 
-  const aiResp = await fetch('https://api.openai.com/v1/chat/completions', {
+  const aiResp = await doFetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${Deno.env.get('OPENAI_API_KEY')}`
     },
     body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
+      model: Deno.env.get('OPENAI_MODEL') ?? 'gpt-4',
       messages: [{ role: 'system', content: systemPrompt }, ...context]
     })
   }).then((res) => res.json())
 
-  const content = aiResp.choices?.[0]?.message?.content ?? ''
+  const content = aiResp.choices?.[0]?.message?.content?.trim() ?? ''
 
   const { data: message } = await supabase
     .from('messages')
@@ -76,8 +104,32 @@ serve(async (req) => {
     .select()
     .single()
 
-  return new Response(
-    JSON.stringify({ ok: true, message }),
-    { headers: { 'Content-Type': 'application/json' } }
-  )
+  try {
+    const channel = supabase.channel('ai-replies')
+    await channel.send({ type: 'broadcast', event: 'new', payload: message })
+    await channel.unsubscribe()
+  } catch (_e) {
+    console.log('broadcast failed')
+  }
+
+  return { acted: true, reply: content }
+}
+
+serve(async (req) => {
+  try {
+    const payload: Payload = await req.json()
+    const result = await handleRouteToAI(payload)
+    if (!result.acted) {
+      return new Response(null, { status: 204 })
+    }
+    return new Response(
+      JSON.stringify({ success: true, reply: result.reply }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error(err)
+    const status = err.message === 'invalid payload' ? 400 : 500
+    return new Response(err.message, { status })
+  }
 })
+

--- a/supabase/functions/test-utils/mockSupabaseClient.ts
+++ b/supabase/functions/test-utils/mockSupabaseClient.ts
@@ -1,8 +1,64 @@
-export function createMockClient() {
+export function createMockClient(data: {
+  conversation?: any
+  messages?: any[]
+  user?: any
+  organization?: any
+} = {}) {
   return {
-    from: () => ({
-      insert: () => ({ select: () => Promise.resolve({ data: {} }) }),
-      select: () => ({ single: () => Promise.resolve({ data: {} }) })
-    })
+    from(table: string) {
+      switch (table) {
+        case 'conversations':
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: data.conversation })
+              })
+            })
+          }
+        case 'users':
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: data.user })
+              })
+            })
+          }
+        case 'messages':
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => Promise.resolve({ data: data.messages })
+                }),
+                single: () => Promise.resolve({ data: data.messages?.[0] })
+              })
+            }),
+            insert: (vals: any) => ({
+              select: () =>
+                Promise.resolve({ data: { id: 'new-id', ...vals } }),
+              single: () =>
+                Promise.resolve({ data: { id: 'new-id', ...vals } })
+            })
+          }
+        case 'organizations':
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: data.organization })
+              })
+            })
+          }
+        default:
+          return {
+            select: () => ({ single: () => Promise.resolve({ data: {} }) })
+          }
+      }
+    },
+    channel() {
+      return {
+        send: async () => {},
+        unsubscribe: async () => {}
+      }
+    }
   }
 }

--- a/supabase/functions/tests/route-to-ai.test.ts
+++ b/supabase/functions/tests/route-to-ai.test.ts
@@ -1,6 +1,27 @@
 import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
+import { handleRouteToAI } from '../route-to-ai.ts'
+import { createMockClient } from '../test-utils/mockSupabaseClient.ts'
 
-Deno.test('route-to-ai returns structured reply', async () => {
-  // TODO: mock OpenAI call
-  assertEquals(true, true)
+Deno.test('route-to-ai returns AI reply', async () => {
+  const mockFetch = (_url: string, _opts: any) =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: 'Sure, I can help!' } }]
+        })
+    })
+
+  const client = createMockClient({
+    conversation: { assigned_user_id: null },
+    messages: [{ sender: 'customer', content: 'Hello?' }],
+    organization: { metadata: { tone: 'formal' } }
+  })
+
+  const res = await handleRouteToAI(
+    { conversation_id: '1', message_id: 'm1', organization_id: 'o1' },
+    { supabase: client, fetcher: mockFetch as any }
+  )
+
+  assertEquals(res.acted, true)
+  assertEquals(res.reply, 'Sure, I can help!')
 })


### PR DESCRIPTION
## Summary
- implement `route-to-ai` edge function with OpenAI call
- add better mocking utilities
- add unit test with mocked OpenAI response

## Testing
- `deno test -A` *(fails: `deno` not installed)*