### PR TITLE
Add Kubernetes manifests for Faladesk services

### DIFF
--- a/k8s/ai-router-deployment.yaml
+++ b/k8s/ai-router-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-router
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: ai-router
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: ai-router
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: ai-router
+    spec:
+      containers:
+        - name: ai-router
+          image: your-docker-registry/faladesk-ai-router:latest
+          ports:
+            - containerPort: 8787
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: OPENAI_API_KEY
+            - name: OPENAI_MODEL
+              valueFrom:
+                configMapKeyRef:
+                  name: faladesk-config
+                  key: OPENAI_MODEL
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/ai-router-hpa.yaml
+++ b/k8s/ai-router-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ai-router
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: ai-router
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ai-router
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/ai-router-service.yaml
+++ b/k8s/ai-router-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-router
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: ai-router
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: ai-router
+  ports:
+    - port: 8787
+      targetPort: 8787
+      protocol: TCP

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: faladesk-config
+  namespace: faladesk
+data:
+  VITE_SUPABASE_URL: "https://supabase.example.com"
+  OPENAI_MODEL: "gpt-3.5-turbo"

--- a/k8s/edge-functions-deployment.yaml
+++ b/k8s/edge-functions-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-functions
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: edge-functions
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: edge-functions
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: edge-functions
+    spec:
+      containers:
+        - name: edge-functions
+          image: supabase/edge-runtime:v1.0.0
+          ports:
+            - containerPort: 54321
+          env:
+            - name: SUPABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: faladesk-config
+                  key: VITE_SUPABASE_URL
+            - name: SUPABASE_SERVICE_ROLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: SUPABASE_SERVICE_ROLE_KEY
+          volumeMounts:
+            - name: functions
+              mountPath: /home/deno/functions
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: functions
+          emptyDir: {}

--- a/k8s/edge-functions-service.yaml
+++ b/k8s/edge-functions-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-functions
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: edge-functions
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: edge-functions
+  ports:
+    - port: 54321
+      targetPort: 54321
+      protocol: TCP

--- a/k8s/email-adapter-deployment.yaml
+++ b/k8s/email-adapter-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email-adapter
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: email-adapter
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: email-adapter
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: email-adapter
+    spec:
+      containers:
+        - name: email-adapter
+          image: your-docker-registry/faladesk-email-adapter:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: SUPABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: faladesk-config
+                  key: VITE_SUPABASE_URL
+            - name: SUPABASE_SERVICE_ROLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: SUPABASE_SERVICE_ROLE_KEY
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/email-adapter-service.yaml
+++ b/k8s/email-adapter-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: email-adapter
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: email-adapter
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: email-adapter
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: frontend
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: your-docker-registry/faladesk-frontend:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: VITE_SUPABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: faladesk-config
+                  key: VITE_SUPABASE_URL
+            - name: VITE_SUPABASE_ANON_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: VITE_SUPABASE_ANON_KEY
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: faladesk
+  namespace: faladesk
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+          - path: /api/route-to-ai
+            pathType: Prefix
+            backend:
+              service:
+                name: ai-router
+                port:
+                  number: 8787
+          - path: /api/receive-whatsapp
+            pathType: Prefix
+            backend:
+              service:
+                name: whatsapp-adapter
+                port:
+                  number: 3000
+          - path: /api/receive-email
+            pathType: Prefix
+            backend:
+              service:
+                name: email-adapter
+                port:
+                  number: 3000

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: faladesk
+  labels:
+    app: faladesk

--- a/k8s/redis-deployment.yaml
+++ b/k8s/redis-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: redis
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: redis
+    spec:
+      containers:
+        - name: redis
+          image: bitnami/redis:7.0
+          ports:
+            - containerPort: 6379
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "yes"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"

--- a/k8s/redis-service.yaml
+++ b/k8s/redis-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: faladesk-secrets
+  namespace: faladesk
+type: Opaque
+stringData:
+  VITE_SUPABASE_ANON_KEY: "replace-me"
+  SUPABASE_SERVICE_ROLE_KEY: "replace-me"
+  SUPABASE_ANON_KEY: "replace-me"
+  OPENAI_API_KEY: "replace-me"
+  TWILIO_AUTH_TOKEN: "replace-me"
+  D360_API_KEY: "replace-me"

--- a/k8s/whatsapp-adapter-deployment.yaml
+++ b/k8s/whatsapp-adapter-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whatsapp-adapter
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: whatsapp-adapter
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faladesk
+      component: whatsapp-adapter
+  template:
+    metadata:
+      labels:
+        app: faladesk
+        component: whatsapp-adapter
+    spec:
+      containers:
+        - name: whatsapp-adapter
+          image: your-docker-registry/faladesk-whatsapp-adapter:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: TWILIO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: TWILIO_AUTH_TOKEN
+            - name: D360_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: D360_API_KEY
+            - name: SUPABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: faladesk-config
+                  key: VITE_SUPABASE_URL
+            - name: SUPABASE_SERVICE_ROLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: faladesk-secrets
+                  key: SUPABASE_SERVICE_ROLE_KEY
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/whatsapp-adapter-service.yaml
+++ b/k8s/whatsapp-adapter-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: whatsapp-adapter
+  namespace: faladesk
+  labels:
+    app: faladesk
+    component: whatsapp-adapter
+spec:
+  type: ClusterIP
+  selector:
+    app: faladesk
+    component: whatsapp-adapter
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP


### PR DESCRIPTION
## Summary
- provide Kubernetes deployment manifests under `k8s/`
- include namespace, configmap, secrets and service/deployment per component
- add HPA for AI router and Ingress routes
- supply a simple Redis instance and optional edge-functions deployment

## Testing
- `npm run test` *(fails: vitest not installed)*
- `deno test -A` *(fails: `deno` command not found)*