### PR TITLE
Fix gluestack peer deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install frontend deps
         run: |
           cd web
-          npm install
+          npm install --legacy-peer-deps
       - name: Run frontend tests
         run: |
           cd web

--- a/web/package.json
+++ b/web/package.json
@@ -10,13 +10,10 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@gluestack-ui/themed": "^0.1.0",
-    "@gluestack-style/react-native-style-sheet": "^0.1.0",
+    "@gluestack-ui/themed": "0.1.55",
     "@supabase/supabase-js": "^2.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-native-safe-area-context": "^4.7.0",
-    "react-native-svg": "^13.9.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",


### PR DESCRIPTION
## Summary
- pin `@gluestack-ui/themed` to a React 18-compatible release
- drop unused React Native deps from web
- use `npm install --legacy-peer-deps` in CI

## Testing
- `npm run test -- --run` *(fails: vitest not found)*
- `deno test -A` *(fails: command not found)*