### PR TITLE
Fix React 18 frontend deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ARG VITE_SUPABASE_ANON_KEY
 ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
 ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
 
+RUN cd web && npm install --legacy-peer-deps
 RUN cd web && npm install && npm run build
 
 # Production stage

--- a/web/package.json
+++ b/web/package.json
@@ -12,12 +12,12 @@
   "dependencies": {
     "@gluestack-ui/themed": "0.1.55",
     "@supabase/supabase-js": "^2.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.1.3",
     "vite": "^4.4.9",


### PR DESCRIPTION
## Summary
- pin React and types to 18.2.0
- keep gluestack-ui/themed pinned for React 18 compatibility
- avoid peer dependency conflicts using legacy install

## Testing
- `npm run test -- --run` *(fails: vitest not found)*
- `deno test -A` *(fails: command not found)*