### PR TITLE
Add auth signup flow with Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 # Logs
 npm-debug.log*
 yarn-debug.log*
+web/package-lock.json
 yarn-error.log*
 
 # Environment variables

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -8,7 +8,8 @@ create table if not exists organizations (
 
 
 create table if not exists users (
-  id uuid primary key references auth.users on delete cascade,
+  id uuid primary key default gen_random_uuid(),
+  supabase_uid uuid not null references auth.users on delete cascade,
   email text not null,
   name text,
   avatar_url text,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,11 @@
-import { VStack } from 'gluestack-ui'
+import { VStack } from '@gluestack-ui/themed'
 import { useAuth } from './lib/AuthProvider'
 import Landing from './components/Landing'
 import Login from './components/Login'
+import SignUp from './components/SignUp'
+import MagicLink from './components/MagicLink'
+import CreateCompany from './components/CreateCompany'
+import DashboardRedirect from './components/DashboardRedirect'
 import { Inbox } from './components/Inbox'
 
 export default function App() {
@@ -11,7 +15,11 @@ export default function App() {
     return null
   }
 
+  const path = window.location.pathname
+
   if (!session) {
+    if (path === '/signup') return <SignUp />
+    if (path === '/magic-link') return <MagicLink />
     return (
       <VStack space="md" p="$4">
         <Landing />
@@ -20,5 +28,13 @@ export default function App() {
     )
   }
 
-  return <Inbox />
+  if (path === '/create-company') {
+    return <CreateCompany />
+  }
+
+  if (path === '/dashboard') {
+    return <Inbox />
+  }
+
+  return <DashboardRedirect />
 }

--- a/web/src/components/CreateCompany.tsx
+++ b/web/src/components/CreateCompany.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { VStack, Input, InputField, Button, Text } from '@gluestack-ui/themed'
+import { supabase } from '../lib/supabase'
+import { useAuth } from '../lib/AuthProvider'
+
+export default function CreateCompany() {
+  const { session } = useAuth()
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!session) return
+    setError(null)
+    const orgSlug = slug || name.toLowerCase().replace(/\s+/g, '-')
+    const { data: org, error: orgError } = await supabase
+      .from('organizations')
+      .insert({ name, slug: orgSlug })
+      .select()
+      .single()
+    if (orgError) {
+      setError(orgError.message)
+      return
+    }
+
+    const { error: userError } = await supabase.from('users').insert({
+      supabase_uid: session.user.id,
+      email: session.user.email,
+      organization_id: org.id,
+      role: 'admin',
+    })
+
+    if (userError) {
+      setError(userError.message)
+    } else {
+      window.location.pathname = '/dashboard'
+    }
+  }
+
+  return (
+    <VStack as="form" space="md" p="$4" onSubmit={handleSubmit}>
+      <Input>
+        <InputField
+          placeholder="Company Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </Input>
+      <Input>
+        <InputField
+          placeholder="slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+        />
+      </Input>
+      {error && <Text color="$error500">{error}</Text>}
+      <Button type="submit">
+        <Text>Create Company</Text>
+      </Button>
+    </VStack>
+  )
+}

--- a/web/src/components/DashboardRedirect.tsx
+++ b/web/src/components/DashboardRedirect.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { useUserOrganization } from '../lib/useUserOrganization'
+
+export default function DashboardRedirect() {
+  const { user, loading } = useUserOrganization()
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user) {
+        window.location.pathname = '/create-company'
+      } else {
+        window.location.pathname = '/dashboard'
+      }
+    }
+  }, [user, loading])
+
+  return null
+}

--- a/web/src/components/Inbox.tsx
+++ b/web/src/components/Inbox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Box, Button, Text, VStack } from 'gluestack-ui'
+import { Box, Button, Text, VStack } from '@gluestack-ui/themed'
 
 interface Message {
   id: string

--- a/web/src/components/Landing.tsx
+++ b/web/src/components/Landing.tsx
@@ -1,4 +1,4 @@
-import { Heading, Text, VStack } from 'gluestack-ui'
+import { Heading, Text, VStack } from '@gluestack-ui/themed'
 
 export default function Landing() {
   return (

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, Input, InputField, VStack, Text } from 'gluestack-ui'
+import { Button, Input, InputField, VStack, Text } from '@gluestack-ui/themed'
 import { useAuth } from '../lib/AuthProvider'
 
 export default function Login() {

--- a/web/src/components/MagicLink.tsx
+++ b/web/src/components/MagicLink.tsx
@@ -1,0 +1,9 @@
+import { VStack, Text } from '@gluestack-ui/themed'
+
+export default function MagicLink() {
+  return (
+    <VStack space="md" p="$4">
+      <Text>Check your inbox for a magic link.</Text>
+    </VStack>
+  )
+}

--- a/web/src/components/SignUp.tsx
+++ b/web/src/components/SignUp.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { VStack, Input, InputField, Button, Text } from '@gluestack-ui/themed'
+import { supabase } from '../lib/supabase'
+
+export default function SignUp() {
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    if (error) {
+      setError(error.message)
+    } else {
+      setSent(true)
+      setEmail('')
+      window.history.pushState(null, '', '/magic-link')
+    }
+  }
+
+  if (sent) {
+    return (
+      <VStack space="md" p="$4">
+        <Text>Check your inbox for a magic link.</Text>
+      </VStack>
+    )
+  }
+
+  return (
+    <VStack as="form" space="md" p="$4" onSubmit={handleSubmit}>
+      <Input>
+        <InputField
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </Input>
+      {error && <Text color="$error500">{error}</Text>}
+      <Button type="submit">
+        <Text>Send Magic Link</Text>
+      </Button>
+    </VStack>
+  )
+}

--- a/web/src/lib/useUserOrganization.ts
+++ b/web/src/lib/useUserOrganization.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { supabase } from './supabase'
+import { useAuth } from './AuthProvider'
+
+interface UserRow {
+  id: string
+  email: string
+  organization_id: string
+  role: string
+  organization?: {
+    id: string
+    name: string
+    slug: string
+  }
+}
+
+export function useUserOrganization() {
+  const { session } = useAuth()
+  const [user, setUser] = useState<UserRow | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!session) return
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from('users')
+        .select(
+          'id, email, organization_id, role, organization:organizations(id, name, slug)'
+        )
+        .eq('supabase_uid', session.user.id)
+        .maybeSingle()
+
+      if (error) {
+        setUser(null)
+      } else {
+        setUser(data as UserRow)
+      }
+      setLoading(false)
+    }
+    fetchData()
+  }, [session])
+
+  return { user, loading }
+}


### PR DESCRIPTION
## Summary
- extend schema for organizations/users
- add signup, magic link, and organization creation components
- create DashboardRedirect and user/org hook
- update imports to `@gluestack-ui/themed`
- add simple path-based routing in `App`

## Testing
- `npm test` *(fails: Failed to resolve import "@gluestack-style/react")*