### PR TITLE
Stub native modules for Vite build

### DIFF
--- a/web/shims/empty-module.js
+++ b/web/shims/empty-module.js
@@ -1,0 +1,1 @@
+export default {}

--- a/web/shims/gluestack-style-react.js
+++ b/web/shims/gluestack-style-react.js
@@ -1,0 +1,1 @@
+export default {}

--- a/web/shims/gluestack-ui-provider.js
+++ b/web/shims/gluestack-ui-provider.js
@@ -1,0 +1,3 @@
+export const GluestackUIContextProvider = ({ children }) => children
+export const createProvider = () => ({ children }) => children
+export default { GluestackUIContextProvider, createProvider }

--- a/web/shims/react-native-svg.js
+++ b/web/shims/react-native-svg.js
@@ -1,0 +1,32 @@
+export const Svg = () => null
+export const Polygon = () => null
+export const Rect = () => null
+export const Circle = () => null
+export const Ellipse = () => null
+export const Line = () => null
+export const Polyline = () => null
+export const Path = () => null
+export const Text = () => null
+export const TSpan = () => null
+export const TextPath = () => null
+export const G = () => null
+export const ClipPath = () => null
+export const LinearGradient = () => null
+export const RadialGradient = () => null
+export default {
+  Svg,
+  Polygon,
+  Rect,
+  Circle,
+  Ellipse,
+  Line,
+  Polyline,
+  Path,
+  Text,
+  TSpan,
+  TextPath,
+  G,
+  ClipPath,
+  LinearGradient,
+  RadialGradient
+}

--- a/web/shims/react-native.js
+++ b/web/shims/react-native.js
@@ -1,0 +1,18 @@
+export const BackHandler = {}
+export const Platform = {}
+export const StatusBar = {}
+export const View = () => null
+export const StyleSheet = { create: () => ({}) }
+export const Dimensions = { get: () => ({}) }
+export const I18nManager = {}
+export const PanResponder = {}
+export default {
+  BackHandler,
+  Platform,
+  StatusBar,
+  View,
+  StyleSheet,
+  Dimensions,
+  I18nManager,
+  PanResponder
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,45 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'url'
+
+// Helper to resolve local shim modules
+const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url))
+
+// Temporary aliases for native-only modules used by @gluestack-ui/themed
+// This allows the web build to proceed until native dependencies are removed
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'react-native': shim('./shims/react-native.js'),
+      'react-native-svg': shim('./shims/react-native-svg.js'),
+      '@gluestack-style/react': shim('./shims/gluestack-style-react.js'),
+      '@gluestack-ui/provider': shim('./shims/gluestack-ui-provider.js'),
+    }
+  },
+  optimizeDeps: {
+    exclude: [
+      'react-native',
+      'react-native-svg',
+      '@gluestack-style/react'
+    ]
+  },
+  build: {
+    commonjsOptions: {
+      transformMixedEsModules: true,
+      namedExports: {
+        '@gluestack-ui/provider': ['GluestackUIContextProvider']
+      }
+    },
+    rollupOptions: {
+      external: [
+        'react-native',
+        'react-native-svg',
+        '@gluestack-style/react'
+      ]
+    }
+  },
   server: {
     host: '0.0.0.0',     // Exposes the dev server externally (e.g. in Docker)
     port: 3000,           // Optional: match your Docker port

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'url'
+
+const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'react-native': shim('./shims/react-native.js'),
+      'react-native-svg': shim('./shims/react-native-svg.js'),
+      '@gluestack-style/react': shim('./shims/gluestack-style-react.js'),
+      '@gluestack-ui/provider': shim('./shims/gluestack-ui-provider.js'),
+    }
+  },
   test: {
     include: ['src/**/*.{test,spec}.tsx'],
     environment: 'jsdom',

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,1 +1,43 @@
 import '@testing-library/jest-dom'
+
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+
+vi.mock('react-native-svg', () => {
+  const Stub = () => null
+  return {
+    Svg: Stub,
+    Polygon: Stub,
+    Rect: Stub,
+    Circle: Stub,
+    Ellipse: Stub,
+    Line: Stub,
+    Polyline: Stub,
+    Path: Stub,
+    Text: Stub,
+    TSpan: Stub,
+    TextPath: Stub,
+    G: Stub,
+    ClipPath: Stub,
+    LinearGradient: Stub,
+    RadialGradient: Stub,
+    default: Stub
+  }
+})
+
+vi.mock('@gluestack-style/react', () => ({}))
+
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children
+}))


### PR DESCRIPTION
## Summary
- stub react-native, react-native-svg and other native-only packages
- alias shims in both Vite and Vitest configs
- mock modules in Vitest setup

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'react-native')*