### PR TITLE
Fix supabase service start in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - .:/app
     working_dir: /app
-    entrypoint: ["supabase"]
+    entrypoint: ["supabase", "start"]
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Summary
- run `supabase start` inside supabase service

## Testing
- `npm run test` in `web`
- `deno test -A` *(fails: `deno` not found)*