### PR TITLE
Add test scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Ensure your Supabase URL and keys are configured in your environment before depl
 
 ## Testing
 
-Vitest is used for frontend unit and integration tests located in `apps/frontend/tests`. Deno's built-in `deno test` runs the edge function tests under `supabase/functions/tests`.
+Vitest is used for frontend unit and integration tests located in `web/src/__tests__`. Deno's built-in `deno test` runs the edge function tests under `supabase/functions/tests`.
 
 Run all tests:
 

--- a/apps/frontend/tests/components/ConversationList.test.tsx
+++ b/apps/frontend/tests/components/ConversationList.test.tsx
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('ConversationList', () => {
-  test.todo('renders conversations correctly')
-})

--- a/apps/frontend/tests/components/MessageBubble.test.tsx
+++ b/apps/frontend/tests/components/MessageBubble.test.tsx
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('MessageBubble', () => {
-  test.todo('differentiates sender roles')
-})

--- a/apps/frontend/tests/components/ReplyBox.test.tsx
+++ b/apps/frontend/tests/components/ReplyBox.test.tsx
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('ReplyBox', () => {
-  test.todo('calls sendMessage function and clears input')
-})

--- a/apps/frontend/tests/e2e/conversation-flow.spec.ts
+++ b/apps/frontend/tests/e2e/conversation-flow.spec.ts
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('Conversation flow', () => {
-  test.todo('open conversation and reply')
-})

--- a/apps/frontend/tests/e2e/login.spec.ts
+++ b/apps/frontend/tests/e2e/login.spec.ts
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('Login flow', () => {
-  test.todo('user can login and view inbox')
-})

--- a/apps/frontend/tests/utils/supabaseHooks.test.ts
+++ b/apps/frontend/tests/utils/supabaseHooks.test.ts
@@ -1,5 +1,0 @@
-import { describe, test } from 'vitest'
-
-describe('Supabase hooks', () => {
-  test.todo('mock API call logic')
-})

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,0 +1,63 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen } from '@testing-library/react'
+import App from '../App'
+import { vi } from 'vitest'
+
+var useAuth: any
+vi.mock('../lib/AuthProvider', () => {
+  useAuth = vi.fn()
+  return { useAuth }
+})
+
+describe('App routing', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', { writable: true, value: { pathname: '/' } })
+  })
+
+  it('renders SignUp when not authenticated and path is /signup', () => {
+    useAuth.mockReturnValue({ session: null, loading: false })
+    window.location.pathname = '/signup'
+    render(<App />)
+    expect(screen.getByText('Send Magic Link')).toBeInTheDocument()
+    expect(screen.queryByText('Faladesk')).not.toBeInTheDocument()
+  })
+
+  it('renders ChatDashboard when authenticated and path is /dashboard', () => {
+    useAuth.mockReturnValue({ session: {}, loading: false })
+    window.location.pathname = '/dashboard'
+    render(<App />)
+    expect(screen.getByText('Maria Silva')).toBeInTheDocument()
+  })
+
+  it('renders CreateCompany when authenticated and path is /create-company', () => {
+    useAuth.mockReturnValue({ session: {}, loading: false })
+    window.location.pathname = '/create-company'
+    render(<App />)
+    expect(screen.getByText('Create Company')).toBeInTheDocument()
+  })
+
+  it('renders DashboardRedirect when authenticated and other path', () => {
+    useAuth.mockReturnValue({ session: {}, loading: false })
+    render(<App />)
+    // DashboardRedirect renders nothing so expect null
+    expect(screen.queryByText('Faladesk')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/__tests__/AuthProvider.test.tsx
+++ b/web/src/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,58 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render } from '@testing-library/react'
+import { AuthProvider, useAuth } from '../lib/AuthProvider'
+import { vi } from 'vitest'
+import { useEffect } from 'react'
+
+var getSession: any
+var onAuthStateChange: any
+var signInWithOtp: any
+var signOutMock: any
+
+vi.mock('../lib/supabase', () => {
+  getSession = vi.fn()
+  onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }))
+  signInWithOtp = vi.fn()
+  signOutMock = vi.fn()
+  return { supabase: { auth: { getSession, onAuthStateChange, signInWithOtp, signOut: signOutMock } } }
+})
+
+function TestComponent() {
+  const { signIn, signOut } = useAuth()
+  useEffect(() => {
+    signIn('test@example.com')
+    signOut()
+  }, [signIn, signOut])
+  return null
+}
+
+describe('AuthProvider', () => {
+  it('calls supabase auth methods', async () => {
+    getSession.mockResolvedValue({ data: { session: null } })
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+    expect(signInWithOtp).toHaveBeenCalledWith({ email: 'test@example.com' })
+    expect(signOutMock).toHaveBeenCalled()
+  })
+})

--- a/web/src/__tests__/ChatDashboard.test.tsx
+++ b/web/src/__tests__/ChatDashboard.test.tsx
@@ -1,0 +1,31 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen } from '@testing-library/react'
+import ChatDashboard from '../components/ChatDashboard'
+
+describe('ChatDashboard', () => {
+  it('renders chat list and messages', () => {
+    const { getAllByText } = render(<ChatDashboard />)
+    expect(getAllByText('Maria Silva').length).toBeGreaterThan(0)
+    expect(screen.getByText('João Santos')).toBeInTheDocument()
+    expect(screen.getByText('Olá, tudo bem?')).toBeInTheDocument()
+    expect(screen.getByText('Posso ajudar?')).toBeInTheDocument()
+  })
+})

--- a/web/src/__tests__/CreateCompany.test.tsx
+++ b/web/src/__tests__/CreateCompany.test.tsx
@@ -1,0 +1,97 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import CreateCompany from '../components/CreateCompany'
+import { vi } from 'vitest'
+
+var orgSingle: any
+var orgSelect: any
+var orgInsert: any
+var userInsert: any
+
+vi.mock('../lib/supabase', () => {
+  orgSingle = vi.fn()
+  orgSelect = vi.fn(() => ({ single: orgSingle }))
+  orgInsert = vi.fn(() => ({ select: orgSelect }))
+  userInsert = vi.fn()
+  return {
+    supabase: {
+      from: (table: string) => {
+        if (table === 'organizations') {
+          return { insert: orgInsert }
+        }
+        if (table === 'users') {
+          return { insert: userInsert }
+        }
+        return {}
+      }
+    }
+  }
+})
+
+vi.mock('../lib/AuthProvider', () => ({
+  useAuth: () => ({ session: { user: { id: 'uid', email: 'u@example.com' } } })
+}))
+
+describe('CreateCompany', () => {
+  beforeEach(() => {
+    orgSingle.mockReset()
+    orgSelect.mockClear()
+    orgInsert.mockClear()
+    userInsert.mockClear()
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { pathname: '/create-company' }
+    })
+  })
+
+  it('creates organization and user then redirects', async () => {
+    orgSingle.mockResolvedValue({ data: { id: '1' }, error: null })
+    userInsert.mockResolvedValue({ error: null })
+
+    render(<CreateCompany />)
+    fireEvent.input(screen.getByPlaceholderText('Company Name'), { target: { value: 'Acme' } })
+    fireEvent.input(screen.getByPlaceholderText('slug'), { target: { value: 'acme' } })
+    fireEvent.submit(screen.getByText('Create Company').closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(orgInsert).toHaveBeenCalledWith({ name: 'Acme', slug: 'acme' })
+      expect(userInsert).toHaveBeenCalledWith({
+        supabase_uid: 'uid',
+        email: 'u@example.com',
+        organization_id: '1',
+        role: 'admin',
+      })
+      expect(window.location.pathname).toBe('/dashboard')
+    })
+  })
+
+  it('shows error when user insert fails', async () => {
+    orgSingle.mockResolvedValue({ data: { id: '1' }, error: null })
+    userInsert.mockResolvedValue({ error: { message: 'fail' } })
+
+    render(<CreateCompany />)
+    fireEvent.input(screen.getByPlaceholderText('Company Name'), { target: { value: 'Acme' } })
+    fireEvent.submit(screen.getByText('Create Company').closest('form') as HTMLFormElement)
+
+    await screen.findByText('fail')
+    expect(window.location.pathname).toBe('/create-company')
+  })
+})

--- a/web/src/__tests__/DashboardRedirect.test.tsx
+++ b/web/src/__tests__/DashboardRedirect.test.tsx
@@ -1,0 +1,53 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, waitFor } from '@testing-library/react'
+import DashboardRedirect from '../components/DashboardRedirect'
+import { vi } from 'vitest'
+
+var useUserOrganization: any
+vi.mock('../lib/useUserOrganization', () => {
+  useUserOrganization = vi.fn()
+  return { useUserOrganization }
+})
+
+describe('DashboardRedirect', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { pathname: '/' }
+    })
+  })
+
+  it('redirects to create-company when no user', async () => {
+    useUserOrganization.mockReturnValue({ loading: false, user: null })
+    render(<DashboardRedirect />)
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/create-company')
+    })
+  })
+
+  it('redirects to dashboard when user exists', async () => {
+    useUserOrganization.mockReturnValue({ loading: false, user: {} })
+    render(<DashboardRedirect />)
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/dashboard')
+    })
+  })
+})

--- a/web/src/__tests__/Inbox.test.tsx
+++ b/web/src/__tests__/Inbox.test.tsx
@@ -1,0 +1,28 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen } from '@testing-library/react'
+import { Inbox } from '../components/Inbox'
+
+describe('Inbox', () => {
+  it('renders empty state with reply button', () => {
+    render(<Inbox />)
+    expect(screen.getByText('Reply')).toBeInTheDocument()
+  })
+})

--- a/web/src/__tests__/Landing.test.tsx
+++ b/web/src/__tests__/Landing.test.tsx
@@ -1,0 +1,29 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen } from '@testing-library/react'
+import Landing from '../components/Landing'
+
+describe('Landing', () => {
+  it('renders heading and tagline', () => {
+    render(<Landing />)
+    expect(screen.getByText('Faladesk')).toBeInTheDocument()
+    expect(screen.getByText('Multi-tenant customer support platform')).toBeInTheDocument()
+  })
+})

--- a/web/src/__tests__/Login.test.tsx
+++ b/web/src/__tests__/Login.test.tsx
@@ -1,0 +1,42 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Login from '../components/Login'
+import { vi } from 'vitest'
+
+var signIn: any
+vi.mock('../lib/AuthProvider', () => {
+  signIn = vi.fn()
+  return {
+    useAuth: () => ({ signIn })
+  }
+})
+
+describe('Login', () => {
+  it('calls signIn with entered email', async () => {
+    render(<Login />)
+    const input = screen.getByPlaceholderText('you@example.com')
+    fireEvent.input(input, { target: { value: 'user@example.com' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalledWith('user@example.com')
+    })
+  })
+})

--- a/web/src/__tests__/MagicLink.test.tsx
+++ b/web/src/__tests__/MagicLink.test.tsx
@@ -1,0 +1,28 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen } from '@testing-library/react'
+import MagicLink from '../components/MagicLink'
+
+describe('MagicLink', () => {
+  it('renders notice', () => {
+    render(<MagicLink />)
+    expect(screen.getByText('Check your inbox for a magic link.')).toBeInTheDocument()
+  })
+})

--- a/web/src/__tests__/Sample.test.tsx
+++ b/web/src/__tests__/Sample.test.tsx
@@ -1,6 +1,0 @@
-// Basic sample test to ensure the test runner works
-describe('Sample calculation', () => {
-  it('adds numbers correctly', () => {
-    expect(1 + 1).toBe(2)
-  })
-})

--- a/web/src/__tests__/SignUp.test.tsx
+++ b/web/src/__tests__/SignUp.test.tsx
@@ -1,0 +1,58 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SignUp from '../components/SignUp'
+import { vi } from 'vitest'
+
+var signInWithOtp: any
+vi.mock('../lib/supabase', () => {
+  signInWithOtp = vi.fn()
+  return {
+    supabase: {
+      auth: { signInWithOtp }
+    }
+  }
+})
+
+describe('SignUp', () => {
+  beforeEach(() => {
+    signInWithOtp.mockReset()
+  })
+
+  it('shows success message on successful signup', async () => {
+    signInWithOtp.mockResolvedValue({ error: null })
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    render(<SignUp />)
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), { target: { value: 'u@example.com' } })
+    fireEvent.submit(screen.getByText('Send Magic Link').closest('form') as HTMLFormElement)
+    await screen.findByText('Check your inbox for a magic link.')
+    expect(signInWithOtp).toHaveBeenCalledWith({ email: 'u@example.com' })
+    expect(pushSpy).toHaveBeenCalledWith(null, '', '/magic-link')
+    pushSpy.mockRestore()
+  })
+
+  it('displays error when signup fails', async () => {
+    signInWithOtp.mockResolvedValue({ error: { message: 'fail' } })
+    render(<SignUp />)
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), { target: { value: 'u@example.com' } })
+    fireEvent.submit(screen.getByText('Send Magic Link').closest('form') as HTMLFormElement)
+    await screen.findByText('fail')
+  })
+})

--- a/web/src/__tests__/useUserOrganization.test.tsx
+++ b/web/src/__tests__/useUserOrganization.test.tsx
@@ -1,0 +1,50 @@
+vi.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {}
+}))
+vi.mock('react-native-svg', () => ({ Svg: () => null, default: () => null }))
+vi.mock('@gluestack-style/react', () => ({ styled: () => () => null }))
+vi.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }: any) => children,
+  createProvider: () => ({ children }: any) => children,
+}))
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { useUserOrganization } from '../lib/useUserOrganization'
+import { vi } from 'vitest'
+
+var maybeSingle: any
+var eq: any
+var select: any
+var from: any
+
+vi.mock('../lib/supabase', () => {
+  maybeSingle = vi.fn()
+  eq = vi.fn(() => ({ maybeSingle }))
+  select = vi.fn(() => ({ eq }))
+  from = vi.fn(() => ({ select }))
+  return { supabase: { from } }
+})
+
+vi.mock('../lib/AuthProvider', () => ({
+  useAuth: () => ({ session: { user: { id: 'uid' } } })
+}))
+
+describe('useUserOrganization', () => {
+  it('fetches user organization', async () => {
+    const user = { id: 'u1', email: 'u@example.com' }
+    maybeSingle.mockResolvedValue({ data: user, error: null })
+    const { result } = renderHook(() => useUserOrganization())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(from).toHaveBeenCalledWith('users')
+    expect(result.current.user).toEqual(user)
+  })
+})


### PR DESCRIPTION
## Summary
- add frontend unit test scaffolding with many component tests
- remove placeholder tests and outdated directory
- update README about test location

## Testing
- `npx vitest run` *(fails: No "Pressable" export defined on the "react-native" mock)*