### PR TITLE
Add Pressable and TextInput shims

### DIFF
--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -6,6 +6,8 @@ export const Text = () => null
 export const ActivityIndicator = () => null
 export const StyleSheet = { create: () => ({}) }
 export const Dimensions = { get: () => ({}) }
+export const Pressable = () => null
+export const TextInput = () => null
 export const I18nManager = {}
 export const PanResponder = {}
 export const AccessibilityInfo = {
@@ -17,6 +19,8 @@ export default {
   StatusBar,
   View,
   Text,
+  Pressable,
+  TextInput,
   ActivityIndicator,
   StyleSheet,
   Dimensions,

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom'
 vi.mock('react-native', () => ({
   View: () => null,
   Text: () => null,
+  Pressable: () => null,
+  TextInput: () => null,
   ActivityIndicator: () => null,
   StyleSheet: { create: () => ({}) },
   BackHandler: {},


### PR DESCRIPTION
## Summary
- mock Pressable and TextInput for web testing
- extend React Native shim with Pressable and TextInput

## Testing
- `npm run test`