### PR TITLE
Fix CI to install Deno

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
       - name: Install frontend deps
         run: |
           cd web


### PR DESCRIPTION
## Summary
- install Deno before running edge function tests

## Testing
- `npm run test -- --run`