### PR TITLE
Add Jest typings for WhatsApp adapter

### DIFF
--- a/whatsapp-adapter/package.json
+++ b/whatsapp-adapter/package.json
@@ -18,6 +18,10 @@
     "ts-jest": "^29.1.1",
     "jest": "^29.6.1",
     "supertest": "^6.3.3",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.3",
+    "@types/supertest": "^2.0.12",
+    "@types/node": "^18.19.0"
   }
 }

--- a/whatsapp-adapter/tsconfig.json
+++ b/whatsapp-adapter/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "strict": true,
     "outDir": "dist",
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
## Summary
- add missing Jest typings to the WhatsApp adapter package
- configure tsconfig to reference Node and Jest types

## Testing
- `cd web && npm test --silent`
- `cd ../whatsapp-adapter && npm test --silent` *(fails: jest not found)*