### PR TITLE
Enable magic link authentication redirect

### DIFF
--- a/web/src/components/SignUp.tsx
+++ b/web/src/components/SignUp.tsx
@@ -10,7 +10,10 @@ export default function SignUp() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
-    const { error } = await supabase.auth.signInWithOtp({ email })
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/magic-link` }
+    })
     if (error) {
       setError(error.message)
     } else {

--- a/web/src/lib/AuthProvider.tsx
+++ b/web/src/lib/AuthProvider.tsx
@@ -30,7 +30,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   const signIn = async (email: string) => {
-    await supabase.auth.signInWithOtp({ email })
+    await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/magic-link` }
+    })
   }
 
   const signOut = async () => {


### PR DESCRIPTION
## Summary
- update SignUp and AuthProvider to specify `emailRedirectTo` so magic links redirect back

## Testing
- `npm run test -- --run --silent` in `web`
- `deno test -A` *(fails: command not found)*
- `npm test --silent` in `whatsapp-adapter` *(fails: jest not found)*