### PR TITLE
Implement basic routing with mock chats

### DIFF
--- a/web/shims/react-router-dom.tsx
+++ b/web/shims/react-router-dom.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const RouterCtx = createContext({ path: '/', navigate: (p) => {}, params: {} })
+
+export function BrowserRouter({ children }) {
+  const [path, setPath] = useState(window.location.pathname)
+  useEffect(() => {
+    const onPop = () => setPath(window.location.pathname)
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+  const navigate = (to) => {
+    if (to === path) return
+    window.history.pushState(null, '', to)
+    setPath(to)
+  }
+  return (
+    <RouterCtx.Provider value={{ path, navigate, params: {} }}>{children}</RouterCtx.Provider>
+  )
+}
+
+function match(routePath, currentPath) {
+  const r = routePath.split('/').filter(Boolean)
+  const c = currentPath.split('/').filter(Boolean)
+  if (r.length !== c.length) return null
+  const params = {}
+  for (let i = 0; i < r.length; i++) {
+    if (r[i].startsWith(':')) {
+      params[r[i].slice(1)] = c[i]
+    } else if (r[i] !== c[i]) {
+      return null
+    }
+  }
+  return params
+}
+
+export function Routes({ children }) {
+  const { path, navigate } = useContext(RouterCtx)
+  let element = null
+  let params = {}
+  React.Children.forEach(children, (child) => {
+    if (element) return
+    if (!React.isValidElement(child)) return
+    const m = match(child.props.path, path)
+    if (m) {
+      element = child.props.element
+      params = m
+    }
+  })
+  return <RouterCtx.Provider value={{ path, navigate, params }}>{element}</RouterCtx.Provider>
+}
+
+export function Route() {
+  return null
+}
+
+export function Link({ to, children }) {
+  const { navigate } = useContext(RouterCtx)
+  return (
+    <a href={to} onClick={(e) => { e.preventDefault(); navigate(to) }}>{children}</a>
+  )
+}
+
+export function useNavigate() {
+  const { navigate } = useContext(RouterCtx)
+  return navigate
+}
+
+export function useParams() {
+  const { params } = useContext(RouterCtx)
+  return params
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { VStack } from '@gluestack-ui/themed'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { useAuth } from './lib/AuthProvider'
 import Landing from './components/Landing'
 import Login from './components/Login'
@@ -15,26 +16,33 @@ export default function App() {
     return null
   }
 
-  const path = window.location.pathname
-
   if (!session) {
-    if (path === '/signup') return <SignUp />
-    if (path === '/magic-link') return <MagicLink />
     return (
-      <VStack space="md" p="$4">
-        <Landing />
-        <Login />
-      </VStack>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/signup" element={<SignUp />} />
+          <Route path="/magic-link" element={<MagicLink />} />
+          <Route
+            path="*"
+            element={(
+              <VStack space="md" p="$4">
+                <Landing />
+                <Login />
+              </VStack>
+            )}
+          />
+        </Routes>
+      </BrowserRouter>
     )
   }
 
-  if (path === '/create-company') {
-    return <CreateCompany />
-  }
-
-  if (path === '/dashboard') {
-    return <ChatDashboard />
-  }
-
-  return <DashboardRedirect />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/create-company" element={<CreateCompany />} />
+        <Route path="/*" element={<ChatDashboard />} />
+        <Route path="*" element={<DashboardRedirect />} />
+      </Routes>
+    </BrowserRouter>
+  )
 }

--- a/web/src/__tests__/ChatDashboard.test.tsx
+++ b/web/src/__tests__/ChatDashboard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import ChatDashboard from '../components/ChatDashboard'
+import { BrowserRouter } from 'react-router-dom'
+
+describe('ChatDashboard routing', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/')
+  })
+
+  it('shows placeholder on root path', () => {
+    render(
+      <BrowserRouter>
+        <ChatDashboard />
+      </BrowserRouter>
+    )
+    expect(screen.getByText('Select a chat')).toBeInTheDocument()
+  })
+
+  it('navigates to chat when clicking conversation', () => {
+    render(
+      <BrowserRouter>
+        <ChatDashboard />
+      </BrowserRouter>
+    )
+    fireEvent.click(screen.getByText('Alice'))
+    expect(screen.queryByText('Select a chat')).not.toBeInTheDocument()
+    expect(screen.getByText('Hello Alice')).toBeInTheDocument()
+    // left column still shows other conversation
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/ChatDashboard.tsx
+++ b/web/src/components/ChatDashboard.tsx
@@ -1,99 +1,31 @@
-import { useEffect, useState } from 'react'
-import { supabase } from '../lib/supabase'
-import { useRealtimeMessages } from '../lib/useRealtimeMessages'
+import { Link, Routes, Route } from 'react-router-dom'
+import ChatView from './ChatView'
 
 interface Conversation {
   id: string
   customer_name: string
 }
 
+const conversations: Conversation[] = [
+  { id: '1', customer_name: 'Alice' },
+  { id: '2', customer_name: 'Bob' }
+]
+
 export default function ChatDashboard() {
-  const [conversations, setConversations] = useState<Conversation[]>([])
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [input, setInput] = useState('')
-
-  useEffect(() => {
-    const fetchConversations = async () => {
-      const { data } = await supabase
-        .from('conversations')
-        .select('id, customer_name')
-        .order('updated_at', { ascending: false })
-      if (data) setConversations(data as Conversation[])
-    }
-    fetchConversations()
-  }, [])
-
-  const { messages, sendMessage } = useRealtimeMessages(selectedId)
-
-  const handleSend = async () => {
-    if (!input.trim()) return
-    await sendMessage(input.trim())
-    setInput('')
-  }
-
   return (
     <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif' }}>
       <aside style={{ width: '30%', borderRight: '1px solid #ddd', overflowY: 'auto' }}>
         {conversations.map((c) => (
-          <div
-            data-testid="conversation-row"
-            key={c.id}
-            onClick={() => setSelectedId(c.id)}
-            style={{
-              padding: '10px',
-              borderBottom: '1px solid #f0f0f0',
-              background: selectedId === c.id ? '#eee' : undefined,
-              cursor: 'pointer'
-            }}
-          >
-            {c.customer_name}
+          <div key={c.id} style={{ padding: '10px', borderBottom: '1px solid #f0f0f0' }}>
+            <Link to={`/chat/${c.id}`}>{c.customer_name}</Link>
           </div>
         ))}
       </aside>
       <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-        <div style={{ flex: 1, padding: '10px', overflowY: 'auto', background: '#f5f5f5' }}>
-          {messages.map((m) => (
-            <div
-              data-testid="message-row"
-              key={m.id}
-              style={{
-                display: 'flex',
-                justifyContent: m.sender === 'agent' ? 'flex-end' : 'flex-start',
-                marginBottom: '8px'
-              }}
-            >
-              <div
-                style={{
-                  background: m.sender === 'agent' ? '#dcf8c6' : '#fff',
-                  padding: '8px 12px',
-                  borderRadius: '8px',
-                  maxWidth: '70%'
-                }}
-              >
-                {m.content}
-              </div>
-            </div>
-          ))}
-        </div>
-        {selectedId && (
-          <footer style={{ padding: '10px', borderTop: '1px solid #ddd' }}>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault()
-                handleSend()
-              }}
-            >
-              <input
-                data-testid="reply-box"
-                type="text"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                placeholder="Type a message..."
-                style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ccc' }}
-              />
-            </form>
-          </footer>
-        )}
+        <Routes>
+          <Route path="/chat/:chatId" element={<ChatView />} />
+          <Route path="/" element={<div style={{ padding: '10px' }}>Select a chat</div>} />
+        </Routes>
       </main>
     </div>
   )

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+interface Message {
+  id: string
+  sender: string
+  content: string
+}
+
+const initialMessages: Record<string, Message[]> = {
+  '1': [
+    { id: 'm1', sender: 'customer', content: 'Hi' },
+    { id: 'm2', sender: 'agent', content: 'Hello Alice' }
+  ],
+  '2': [
+    { id: 'm3', sender: 'customer', content: 'Hey' },
+    { id: 'm4', sender: 'agent', content: 'Hello Bob' }
+  ]
+}
+
+export default function ChatView() {
+  const { chatId } = useParams<{ chatId: string }>()
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+
+  useEffect(() => {
+    if (chatId) {
+      setMessages(initialMessages[chatId] || [])
+    }
+  }, [chatId])
+
+  const handleSend = () => {
+    if (!input.trim()) return
+    setMessages((m) => [
+      ...m,
+      { id: Date.now().toString(), sender: 'agent', content: input.trim() }
+    ])
+    setInput('')
+  }
+
+  if (!chatId) return null
+
+  return (
+    <>
+      <div style={{ flex: 1, padding: '10px', overflowY: 'auto', background: '#f5f5f5' }}>
+        {messages.map((m) => (
+          <div key={m.id} style={{ display: 'flex', justifyContent: m.sender === 'agent' ? 'flex-end' : 'flex-start', marginBottom: '8px' }}>
+            <div style={{ background: m.sender === 'agent' ? '#dcf8c6' : '#fff', padding: '8px 12px', borderRadius: '8px', maxWidth: '70%' }}>
+              {m.content}
+            </div>
+          </div>
+        ))}
+      </div>
+      <footer style={{ padding: '10px', borderTop: '1px solid #ddd' }}>
+        <form onSubmit={(e) => { e.preventDefault(); handleSend() }}>
+          <input
+            data-testid="reply-box"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message..."
+            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ccc' }}
+          />
+        </form>
+      </footer>
+    </>
+  )
+}

--- a/web/src/components/CreateCompany.tsx
+++ b/web/src/components/CreateCompany.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { VStack, Input, InputField, Button, Text } from '@gluestack-ui/themed'
+import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../lib/AuthProvider'
 
 export default function CreateCompany() {
   const { session } = useAuth()
+  const navigate = useNavigate()
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -34,7 +36,7 @@ export default function CreateCompany() {
     if (userError) {
       setError(userError.message)
     } else {
-      window.location.pathname = '/dashboard'
+      navigate('/')
     }
   }
 

--- a/web/src/components/DashboardRedirect.tsx
+++ b/web/src/components/DashboardRedirect.tsx
@@ -1,15 +1,17 @@
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useUserOrganization } from '../lib/useUserOrganization'
 
 export default function DashboardRedirect() {
   const { user, loading } = useUserOrganization()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (!loading) {
       if (!user) {
-        window.location.pathname = '/create-company'
+        navigate('/create-company')
       } else {
-        window.location.pathname = '/dashboard'
+        navigate('/')
       }
     }
   }, [user, loading])

--- a/web/src/shims-react-router-dom.d.ts
+++ b/web/src/shims-react-router-dom.d.ts
@@ -1,0 +1,9 @@
+declare module 'react-router-dom' {
+  import { ReactNode } from 'react'
+  export function BrowserRouter(props: { children: ReactNode }): JSX.Element
+  export function Routes(props: { children: ReactNode }): JSX.Element
+  export function Route(props: { path: string; element: JSX.Element }): null
+  export function Link(props: { to: string; children: ReactNode }): JSX.Element
+  export function useNavigate(): (to: string) => void
+  export function useParams<T extends Record<string, string | undefined>>(): T
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'react-native-svg': shim('./shims/react-native-svg.mjs'),
       '@gluestack-style/react': shim('./shims/gluestack-style-react.mjs'),
       '@gluestack-ui/provider': shim('./shims/gluestack-ui-provider.mjs'),
+      'react-router-dom': shim('./shims/react-router-dom.tsx'),
     }
   },
   optimizeDeps: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'react-native-svg': shim('./shims/react-native-svg.mjs'),
       '@gluestack-style/react': shim('./shims/gluestack-style-react.mjs'),
       '@gluestack-ui/provider': shim('./shims/gluestack-ui-provider.mjs'),
+      'react-router-dom': shim('./shims/react-router-dom.tsx'),
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- add custom shim for `react-router-dom` and alias in Vite
- update `App` to use `BrowserRouter`
- build `ChatDashboard` and `ChatView` with in-memory data
- navigate with `useNavigate` inside `CreateCompany` and `DashboardRedirect`
- add tests for chat routing

## Testing
- `npm test --silent`