### PR TITLE
Implement onboarding user name and team

### DIFF
--- a/web/src/__tests__/CreateCompany.test.tsx
+++ b/web/src/__tests__/CreateCompany.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import CreateCompany from '../components/CreateCompany'
+import { vi } from 'vitest'
+
+vi.mock('@gluestack-ui/themed', () => {
+  const React = require('react')
+  return {
+    VStack: (props: any) => <div {...props} />,
+    Input: (props: any) => <div {...props} />,
+    InputField: (props: any) => <input {...props} />,
+    Button: (props: any) => <button {...props} />,
+    Text: (props: any) => <span {...props} />,
+  }
+})
+
+vi.mock('../lib/AuthProvider', () => ({
+  useAuth: () => ({ session: { user: { id: '1', email: 'test@example.com' } } })
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn(() => ({ data: { id: '1' } })) })) }))
+    }))
+  }
+}))
+
+describe('CreateCompany form', () => {
+  it('renders name and company fields', () => {
+    render(<CreateCompany />)
+    expect(screen.getByPlaceholderText('Your Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Company Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('slug')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/CreateCompany.tsx
+++ b/web/src/components/CreateCompany.tsx
@@ -9,6 +9,7 @@ export default function CreateCompany() {
   const navigate = useNavigate()
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
+  const [userName, setUserName] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -31,6 +32,7 @@ export default function CreateCompany() {
       email: session.user.email,
       organization_id: org.id,
       role: 'admin',
+      name: userName,
     })
 
     if (userError) {
@@ -42,6 +44,13 @@ export default function CreateCompany() {
 
   return (
     <VStack as="form" space="md" p="$4" onSubmit={handleSubmit}>
+      <Input>
+        <InputField
+          placeholder="Your Name"
+          value={userName}
+          onChange={(e) => setUserName(e.target.value)}
+        />
+      </Input>
       <Input>
         <InputField
           placeholder="Company Name"


### PR DESCRIPTION
## Summary
- prompt for user name when creating company/team
- store the name when creating the admin user
- test that the form shows all expected fields

## Testing
- `npm test --silent`
- `deno test -A` *(fails: `deno: command not found`)*