### PR TITLE
Add conversation thread component

### DIFF
--- a/web/src/__tests__/ConversationThread.test.tsx
+++ b/web/src/__tests__/ConversationThread.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import ConversationThread from '../components/ConversationThread'
+import { vi } from 'vitest'
+
+const sampleMessages = [
+  {
+    id: '1',
+    sender: 'customer',
+    content: 'hi',
+    metadata: { type: 'text' },
+    created_at: '2023-01-01T10:00:00Z'
+  },
+  {
+    id: '2',
+    sender: 'agent',
+    content: 'hello',
+    metadata: { type: 'text' },
+    created_at: '2023-01-01T10:05:00Z'
+  },
+  {
+    id: '3',
+    sender: 'customer',
+    content: null,
+    metadata: { type: 'image', url: 'img.jpg' },
+    created_at: '2023-01-02T12:00:00Z'
+  },
+  {
+    id: '4',
+    sender: 'agent',
+    content: null,
+    metadata: { type: 'audio', url: 'audio.mp3' },
+    created_at: '2023-01-02T13:00:00Z'
+  }
+]
+
+vi.mock('../lib/useRealtimeMessages', () => ({
+  useRealtimeMessages: () => ({
+    messages: sampleMessages,
+    sendMessage: vi.fn()
+  })
+}))
+
+describe('ConversationThread', () => {
+  it('renders date separators and different message types', () => {
+    render(<ConversationThread conversationId="1" />)
+    const separators = screen.getAllByTestId('date-separator')
+    expect(separators.length).toBe(2)
+    expect(screen.getByTestId('image-3')).toHaveAttribute('src', 'img.jpg')
+    expect(screen.getByTestId('audio-4')).toHaveAttribute('src', 'audio.mp3')
+  })
+})

--- a/web/src/components/ConversationThread.tsx
+++ b/web/src/components/ConversationThread.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react'
+import { useRealtimeMessages, RealtimeMessage } from '../lib/useRealtimeMessages'
+
+interface Props {
+  conversationId: string | null
+}
+
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr)
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatTime(dateStr: string) {
+  const d = new Date(dateStr)
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function avatarFor(sender: string) {
+  if (sender === 'agent' || sender === 'ai') {
+    return 'https://via.placeholder.com/32/007bff/ffffff?text=A'
+  }
+  return 'https://via.placeholder.com/32/cccccc/000000?text=U'
+}
+
+function MessageBubble({ message }: { message: RealtimeMessage }) {
+  const type = message.metadata?.type || 'text'
+  const url = message.metadata?.url
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: message.sender === 'agent' || message.sender === 'ai' ? 'flex-end' : 'flex-start',
+        marginBottom: '8px'
+      }}
+    >
+      {message.sender !== 'agent' && message.sender !== 'ai' && (
+        <img src={avatarFor(message.sender)} alt="avatar" style={{ width: 32, height: 32, borderRadius: '50%', marginRight: 8 }} />
+      )}
+      <div
+        style={{
+          background: message.sender === 'agent' || message.sender === 'ai' ? '#dcf8c6' : '#fff',
+          padding: '8px 12px',
+          borderRadius: '8px',
+          maxWidth: '70%'
+        }}
+      >
+        {type === 'image' && url ? <img data-testid={`image-${message.id}`} src={url} alt="image" style={{ maxWidth: '100%' }} /> : null}
+        {type === 'audio' && url ? <audio data-testid={`audio-${message.id}`} controls src={url} /> : null}
+        {type === 'text' || !url ? <div>{message.content}</div> : null}
+        <div style={{ fontSize: '10px', textAlign: 'right', color: '#999' }}>{formatTime(message.created_at)}</div>
+      </div>
+      {(message.sender === 'agent' || message.sender === 'ai') && (
+        <img src={avatarFor(message.sender)} alt="avatar" style={{ width: 32, height: 32, borderRadius: '50%', marginLeft: 8 }} />
+      )}
+    </div>
+  )
+}
+
+export default function ConversationThread({ conversationId }: Props) {
+  const { messages } = useRealtimeMessages(conversationId)
+
+  const grouped = useMemo(() => {
+    const groups: { date: string; items: RealtimeMessage[] }[] = []
+    messages.forEach((m) => {
+      const date = m.created_at.split('T')[0]
+      const existing = groups.find((g) => g.date === date)
+      if (existing) {
+        existing.items.push(m)
+      } else {
+        groups.push({ date, items: [m] })
+      }
+    })
+    return groups
+  }, [messages])
+
+  return (
+    <div style={{ padding: '10px', overflowY: 'auto' }}>
+      {grouped.map((g) => (
+        <div key={g.date}>
+          <div data-testid="date-separator" style={{ textAlign: 'center', color: '#666', margin: '10px 0' }}>
+            {formatDate(g.date)}
+          </div>
+          {g.items.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/lib/useRealtimeMessages.ts
+++ b/web/src/lib/useRealtimeMessages.ts
@@ -4,7 +4,8 @@ import { supabase } from './supabase'
 export interface RealtimeMessage {
   id: string
   sender: string
-  content: string
+  content: string | null
+  metadata: Record<string, any> | null
   created_at: string
 }
 
@@ -19,7 +20,7 @@ export function useRealtimeMessages(conversationId: string | null) {
     const fetchMessages = async () => {
       const { data } = await supabase
         .from('messages')
-        .select('id, sender, content, created_at')
+        .select('id, sender, content, metadata, created_at')
         .eq('conversation_id', conversationId)
         .order('created_at', { ascending: true })
 


### PR DESCRIPTION
## Summary
- add `ConversationThread` component to render grouped message history with timestamps and avatars
- extend `useRealtimeMessages` to include `metadata`
- test date separators and different message types

## Testing
- `npm run test -- --run`
- `deno test -A` *(fails: `deno: command not found`)*