### PR TITLE
Add settings modal component

### DIFF
--- a/web/src/__tests__/SettingsModal.test.tsx
+++ b/web/src/__tests__/SettingsModal.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import ChatDashboard from '../components/ChatDashboard'
+import { BrowserRouter } from 'react-router-dom'
+
+describe('Settings modal', () => {
+  it('opens and closes properly', () => {
+    render(
+      <BrowserRouter>
+        <ChatDashboard />
+      </BrowserRouter>
+    )
+    fireEvent.click(screen.getByText('Settings'))
+    expect(screen.getByText('Agent Settings')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Agent Settings')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/ChatDashboard.tsx
+++ b/web/src/components/ChatDashboard.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Link, Routes, Route } from 'react-router-dom'
 import ChatView from './ChatView'
+import SettingsModal from './SettingsModal'
 
 interface Conversation {
   id: string
@@ -12,8 +14,16 @@ const conversations: Conversation[] = [
 ]
 
 export default function ChatDashboard() {
+  const [showSettings, setShowSettings] = useState(false)
   return (
-    <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif' }}>
+    <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif', position: 'relative' }}>
+      <button
+        style={{ position: 'absolute', top: '10px', right: '10px' }}
+        onClick={() => setShowSettings(true)}
+      >
+        Settings
+      </button>
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
       <aside style={{ width: '30%', borderRight: '1px solid #ddd', overflowY: 'auto' }}>
         {conversations.map((c) => (
           <div key={c.id} style={{ padding: '10px', borderBottom: '1px solid #f0f0f0' }}>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+
+interface SettingsModalProps {
+  onClose: () => void
+}
+
+export default function SettingsModal({ onClose }: SettingsModalProps) {
+  const [name, setName] = useState('')
+  const [available, setAvailable] = useState(true)
+  const [notifications, setNotifications] = useState(true)
+  const [profile, setProfile] = useState<File | null>(null)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // Normally would persist settings here
+    onClose()
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <div style={{ background: '#fff', padding: '20px', borderRadius: '8px', minWidth: '300px' }}>
+        <h2>Agent Settings</h2>
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '8px' }}>
+            <label>
+              Profile Picture
+              <input
+                data-testid="profile-input"
+                type="file"
+                onChange={(e) => setProfile(e.target.files?.[0] || null)}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '8px' }}>
+            <label>
+              Name
+              <input
+                data-testid="name-input"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '8px' }}>
+            <label>
+              Available
+              <input
+                data-testid="available-input"
+                type="checkbox"
+                checked={available}
+                onChange={(e) => setAvailable(e.target.checked)}
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '8px' }}>
+            <label>
+              Notifications
+              <input
+                data-testid="notifications-input"
+                type="checkbox"
+                checked={notifications}
+                onChange={(e) => setNotifications(e.target.checked)}
+              />
+            </label>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+            <button type="button" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `SettingsModal` component to edit profile info
- integrate modal into `ChatDashboard`
- test opening and closing the settings modal

## Testing
- `npm test --silent`