### PR TITLE
Add agent presence indicators

### DIFF
--- a/apps/frontend/tests/utils/supabaseHooks.test.ts
+++ b/apps/frontend/tests/utils/supabaseHooks.test.ts
@@ -1,18 +1,38 @@
 import { renderHook, act } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
 import { useRealtimeMessages } from '../../../web/src/lib/useRealtimeMessages'
+import { useAgentPresence } from '../../../web/src/lib/useAgentPresence'
 
 vi.mock('../../../web/src/lib/supabase', () => {
-  return {
-    supabase: {
-      from: vi.fn(() => ({
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'messages') {
+      return {
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
             order: vi.fn(() => Promise.resolve({ data: [], error: null }))
           }))
         })),
         insert: vi.fn()
-      }),
+      }
+    }
+    if (table === 'users') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: { status: 'offline' } }))
+          }))
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ data: {} }))
+        }))
+      }
+    }
+    return {}
+  })
+
+  return {
+    supabase: {
+      from: fromMock,
       channel: vi.fn(() => ({
         on: vi.fn().mockReturnThis(),
         subscribe: vi.fn().mockReturnThis()
@@ -39,5 +59,25 @@ describe('useRealtimeMessages', () => {
       sender: 'agent',
       content: 'hello'
     })
+  })
+})
+
+describe('useAgentPresence', () => {
+  it('fetches and updates status', async () => {
+    const { result } = renderHook(() => useAgentPresence('agent1'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.status).toBe('offline')
+
+    await act(async () => {
+      await result.current.updateStatus('online')
+    })
+
+    const { supabase } = await import('../../../web/src/lib/supabase')
+    expect((supabase.from as any).mock.calls.some((c: any[]) => c[0] === 'users')).toBe(true)
+    expect(supabase.from().update).toHaveBeenCalledWith({ status: 'online' })
   })
 })

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -18,6 +18,12 @@ create table if not exists users (
   created_at timestamptz default now()
 );
 
+-- Agent presence status
+alter table users
+  add column if not exists status text
+    check (status in ('online','away','offline'))
+    not null default 'offline';
+
 -- Conversations and messages
 create table if not exists conversations (
   id uuid primary key default gen_random_uuid(),

--- a/web/src/__tests__/ChatDashboard.test.tsx
+++ b/web/src/__tests__/ChatDashboard.test.tsx
@@ -1,6 +1,19 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import ChatDashboard from '../components/ChatDashboard'
 import { BrowserRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+vi.mock('../lib/AuthProvider', () => ({
+  useAuth: () => ({ session: { user: { id: 'agent1' } }, loading: false })
+}))
+
+vi.mock('../lib/useAgentPresence', () => ({
+  useAgentPresence: () => ({ status: 'online', updateStatus: vi.fn() })
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: { from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
+}))
 
 describe('ChatDashboard routing', () => {
   beforeEach(() => {

--- a/web/src/lib/useAgentPresence.ts
+++ b/web/src/lib/useAgentPresence.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { supabase } from './supabase'
+
+export type PresenceStatus = 'online' | 'away' | 'offline'
+
+export function useAgentPresence(agentId: string | null) {
+  const [status, setStatus] = useState<PresenceStatus>('offline')
+
+  useEffect(() => {
+    if (!agentId) return
+
+    let channel: ReturnType<typeof supabase.channel> | null = null
+
+    const fetchStatus = async () => {
+      const { data } = await supabase
+        .from('users')
+        .select('status')
+        .eq('id', agentId)
+        .single()
+
+      if (data) setStatus(data.status as PresenceStatus)
+    }
+
+    fetchStatus()
+
+    channel = supabase
+      .channel('users_status:' + agentId)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'users',
+          filter: `id=eq.${agentId}`
+        },
+        (payload) => setStatus((payload.new as any).status as PresenceStatus)
+      )
+      .subscribe()
+
+    return () => {
+      if (channel) supabase.removeChannel(channel)
+    }
+  }, [agentId])
+
+  const updateStatus = async (newStatus: PresenceStatus) => {
+    if (!agentId) return
+    await supabase.from('users').update({ status: newStatus }).eq('id', agentId)
+  }
+
+  return { status, updateStatus }
+}


### PR DESCRIPTION
## Summary
- track agent presence in the database
- hook to update agent presence via Supabase realtime
- show agent status in the chat view
- add corresponding tests and mocks

## Testing
- `npx vitest run`
- `deno test -A` *(fails: `deno` not found)*