### PR TITLE
Add email/password login

### DIFF
--- a/apps/frontend/tests/e2e/login.spec.ts
+++ b/apps/frontend/tests/e2e/login.spec.ts
@@ -2,17 +2,31 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
 import Login from '../../../web/src/components/Login'
 
-const signInMock = vi.fn()
+const passwordLoginMock = vi.fn()
+const magicLoginMock = vi.fn()
 vi.mock('../../../web/src/lib/AuthProvider', () => ({
-  useAuth: () => ({ signIn: signInMock })
+  useAuth: () => ({
+    signInWithPassword: passwordLoginMock,
+    signInWithMagicLink: magicLoginMock
+  })
 }))
 
 describe('Login flow', () => {
-  it('user can login and view inbox', async () => {
+  it('user can login with password', async () => {
     render(<Login />)
-    const input = screen.getByPlaceholderText('you@example.com')
-    fireEvent.change(input, { target: { value: 'user@example.com' } })
-    fireEvent.submit(input.closest('form') as HTMLFormElement)
-    expect(signInMock).toHaveBeenCalledWith('user@example.com')
+    const emailInput = screen.getByPlaceholderText('you@example.com')
+    const passInput = screen.getByPlaceholderText('Password')
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+    fireEvent.change(passInput, { target: { value: 'secret' } })
+    fireEvent.submit(screen.getByTestId('login-form'))
+    expect(passwordLoginMock).toHaveBeenCalledWith('user@example.com', 'secret')
+  })
+
+  it('user can request magic link', async () => {
+    render(<Login />)
+    const emailInput = screen.getByPlaceholderText('you@example.com')
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+    fireEvent.click(screen.getByText('Send Magic Link'))
+    expect(magicLoginMock).toHaveBeenCalledWith('user@example.com')
   })
 })

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -3,27 +3,61 @@ import { Button, Input, InputField, VStack, Text } from '@gluestack-ui/themed'
 import { useAuth } from '../lib/AuthProvider'
 
 export default function Login() {
-  const { signIn } = useAuth()
+  const { signInWithMagicLink, signInWithPassword } = useAuth()
   const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handlePasswordLogin = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError(null)
+    if (email && password) {
+      try {
+        await signInWithPassword(email, password)
+        setEmail('')
+        setPassword('')
+      } catch (err: any) {
+        setError(err.message)
+      }
+    }
+  }
+
+  const handleMagicLink = async () => {
+    setError(null)
     if (email) {
-      await signIn(email)
-      setEmail('')
+      try {
+        await signInWithMagicLink(email)
+        setEmail('')
+      } catch (err: any) {
+        setError(err.message)
+      }
     }
   }
 
   return (
-    <VStack as="form" space="md" onSubmit={handleSubmit}>
-      <Input>
-        <InputField
-          placeholder="you@example.com"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </Input>
-      <Button type="submit">
+    <VStack space="md" p="$4">
+      <VStack as="form" space="md" onSubmit={handlePasswordLogin} data-testid="login-form">
+        <Input>
+          <InputField
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </Input>
+        <Input>
+          <InputField
+            placeholder="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </Input>
+        {error && <Text color="$error500">{error}</Text>}
+        <Button type="submit">
+          <Text>Login</Text>
+        </Button>
+      </VStack>
+      <Button onPress={handleMagicLink} disabled={!email}>
         <Text>Send Magic Link</Text>
       </Button>
     </VStack>

--- a/web/src/components/SignUp.tsx
+++ b/web/src/components/SignUp.tsx
@@ -4,14 +4,16 @@ import { supabase } from '../lib/supabase'
 
 export default function SignUp() {
   const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [sent, setSent] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
-    const { error } = await supabase.auth.signInWithOtp({
+    const { error } = await supabase.auth.signUp({
       email,
+      password,
       options: { emailRedirectTo: `${window.location.origin}/magic-link` }
     })
     if (error) {
@@ -19,14 +21,14 @@ export default function SignUp() {
     } else {
       setSent(true)
       setEmail('')
-      window.history.pushState(null, '', '/magic-link')
+      setPassword('')
     }
   }
 
   if (sent) {
     return (
       <VStack space="md" p="$4">
-        <Text>Check your inbox for a magic link.</Text>
+        <Text>Check your inbox to confirm your email.</Text>
       </VStack>
     )
   }
@@ -40,9 +42,17 @@ export default function SignUp() {
           onChange={(e) => setEmail(e.target.value)}
         />
       </Input>
+      <Input>
+        <InputField
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </Input>
       {error && <Text color="$error500">{error}</Text>}
       <Button type="submit">
-        <Text>Send Magic Link</Text>
+        <Text>Sign Up</Text>
       </Button>
     </VStack>
   )

--- a/web/src/lib/AuthProvider.tsx
+++ b/web/src/lib/AuthProvider.tsx
@@ -5,7 +5,9 @@ import { supabase } from './supabase'
 interface AuthContextProps {
   session: Session | null
   loading: boolean
-  signIn: (email: string) => Promise<void>
+  signInWithMagicLink: (email: string) => Promise<void>
+  signInWithPassword: (email: string, password: string) => Promise<void>
+  signUp: (email: string, password: string) => Promise<void>
   signOut: () => Promise<void>
 }
 
@@ -29,9 +31,21 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return () => subscription.unsubscribe()
   }, [])
 
-  const signIn = async (email: string) => {
+  const signInWithMagicLink = async (email: string) => {
     await supabase.auth.signInWithOtp({
       email,
+      options: { emailRedirectTo: `${window.location.origin}/magic-link` }
+    })
+  }
+
+  const signInWithPassword = async (email: string, password: string) => {
+    await supabase.auth.signInWithPassword({ email, password })
+  }
+
+  const signUp = async (email: string, password: string) => {
+    await supabase.auth.signUp({
+      email,
+      password,
       options: { emailRedirectTo: `${window.location.origin}/magic-link` }
     })
   }
@@ -41,7 +55,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }
 
   return (
-    <AuthContext.Provider value={{ session, loading, signIn, signOut }}>
+    <AuthContext.Provider
+      value={{
+        session,
+        loading,
+        signInWithMagicLink,
+        signInWithPassword,
+        signUp,
+        signOut
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- extend `AuthProvider` to support password login and signup
- update `Login` screen for password login or magic link
- update `SignUp` screen for email/password registration
- adjust login tests for new methods

## Testing
- `CI=1 npm test --silent`
- `deno test -A` *(fails: `deno` not found)*