### PR TITLE
Add realtime subscriptions for chats

### DIFF
--- a/web/shims/react-router-dom.tsx
+++ b/web/shims/react-router-dom.tsx
@@ -70,3 +70,9 @@ export function useParams() {
   const { params } = useContext(RouterCtx)
   return params
 }
+
+export function useMatch(pattern: string) {
+  const { path } = useContext(RouterCtx)
+  const params = match(pattern, path)
+  return params ? { params } : null
+}

--- a/web/src/__tests__/ChatDashboard.test.tsx
+++ b/web/src/__tests__/ChatDashboard.test.tsx
@@ -1,6 +1,24 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
 import ChatDashboard from '../components/ChatDashboard'
 import { BrowserRouter } from 'react-router-dom'
+
+vi.mock('../lib/useConversations', () => ({
+  useConversations: () => ({
+    conversations: [
+      { id: '1', customer_name: 'Alice', unread: 0 },
+      { id: '2', customer_name: 'Bob', unread: 0 }
+    ],
+    clearUnread: vi.fn(),
+  })
+}))
+
+vi.mock('../lib/useRealtimeMessages', () => ({
+  useRealtimeMessages: (id: string | null) => ({
+    messages: id ? [{ id: '1', sender: 'agent', content: id === '1' ? 'Hello Alice' : 'Hello Bob', created_at: '' }] : [],
+    sendMessage: vi.fn(),
+  })
+}))
 
 describe('ChatDashboard routing', () => {
   beforeEach(() => {

--- a/web/src/components/ChatDashboard.tsx
+++ b/web/src/components/ChatDashboard.tsx
@@ -1,29 +1,32 @@
-import { Link, Routes, Route } from 'react-router-dom'
+import { Link, Routes, Route, useMatch } from 'react-router-dom'
 import ChatView from './ChatView'
+import { useConversations } from '../lib/useConversations'
 
-interface Conversation {
-  id: string
-  customer_name: string
-}
-
-const conversations: Conversation[] = [
-  { id: '1', customer_name: 'Alice' },
-  { id: '2', customer_name: 'Bob' }
-]
 
 export default function ChatDashboard() {
+  const match = useMatch('/chat/:chatId')
+  const activeId = (match && match.params.chatId) || null
+  const { conversations, clearUnread } = useConversations(activeId)
+
   return (
     <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif' }}>
       <aside style={{ width: '30%', borderRight: '1px solid #ddd', overflowY: 'auto' }}>
         {conversations.map((c) => (
           <div key={c.id} style={{ padding: '10px', borderBottom: '1px solid #f0f0f0' }}>
-            <Link to={`/chat/${c.id}`}>{c.customer_name}</Link>
+            <Link to={`/chat/${c.id}`} onClick={() => clearUnread(c.id)}>
+              {c.customer_name}
+              {c.unread > 0 && (
+                <span data-testid="unread-count" style={{ marginLeft: 4 }}>
+                  ({c.unread})
+                </span>
+              )}
+            </Link>
           </div>
         ))}
       </aside>
       <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <Routes>
-          <Route path="/chat/:chatId" element={<ChatView />} />
+          <Route path="/chat/:chatId" element={<ChatView clearUnread={clearUnread} />} />
           <Route path="/" element={<div style={{ padding: '10px' }}>Select a chat</div>} />
         </Routes>
       </main>

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1,40 +1,23 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { useRealtimeMessages } from '../lib/useRealtimeMessages'
 
-interface Message {
-  id: string
-  sender: string
-  content: string
-}
-
-const initialMessages: Record<string, Message[]> = {
-  '1': [
-    { id: 'm1', sender: 'customer', content: 'Hi' },
-    { id: 'm2', sender: 'agent', content: 'Hello Alice' }
-  ],
-  '2': [
-    { id: 'm3', sender: 'customer', content: 'Hey' },
-    { id: 'm4', sender: 'agent', content: 'Hello Bob' }
-  ]
-}
-
-export default function ChatView() {
+export default function ChatView({
+  clearUnread,
+}: {
+  clearUnread: (id: string) => void
+}) {
   const { chatId } = useParams<{ chatId: string }>()
-  const [messages, setMessages] = useState<Message[]>([])
+  const { messages, sendMessage } = useRealtimeMessages(chatId || null)
   const [input, setInput] = useState('')
 
   useEffect(() => {
-    if (chatId) {
-      setMessages(initialMessages[chatId] || [])
-    }
-  }, [chatId])
+    if (chatId) clearUnread(chatId)
+  }, [chatId, clearUnread])
 
   const handleSend = () => {
     if (!input.trim()) return
-    setMessages((m) => [
-      ...m,
-      { id: Date.now().toString(), sender: 'agent', content: input.trim() }
-    ])
+    sendMessage(input.trim())
     setInput('')
   }
 

--- a/web/src/lib/useConversations.ts
+++ b/web/src/lib/useConversations.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { supabase } from './supabase'
+
+export interface ConversationRow {
+  id: string
+  customer_name: string | null
+}
+
+export interface ConversationWithUnread extends ConversationRow {
+  unread: number
+}
+
+export function useConversations(activeId: string | null) {
+  const [conversations, setConversations] = useState<ConversationWithUnread[]>([])
+
+  useEffect(() => {
+    const fetchConversations = async () => {
+      const { data } = await supabase
+        .from('conversations')
+        .select('id, customer_name')
+        .order('created_at', { ascending: true })
+
+      if (data) {
+        setConversations((data as ConversationRow[]).map(c => ({ ...c, unread: 0 })))
+      }
+    }
+
+    fetchConversations()
+
+    const channel = supabase
+      .channel('messages-all')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'messages' },
+        payload => {
+          const convId = payload.new.conversation_id as string
+          setConversations(prev => {
+            const idx = prev.findIndex(c => c.id === convId)
+            if (idx === -1) return prev
+            const updated = [...prev]
+            if (convId !== activeId) {
+              updated[idx] = { ...updated[idx], unread: updated[idx].unread + 1 }
+            }
+            return updated
+          })
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [activeId])
+
+  const clearUnread = (id: string) => {
+    setConversations(prev => prev.map(c => (c.id === id ? { ...c, unread: 0 } : c)))
+  }
+
+  return { conversations, clearUnread }
+}


### PR DESCRIPTION
## Summary
- add hook for conversation list with unread tracking
- wire ChatDashboard to Supabase data and show unread counts
- use realtime messages in ChatView and mark read on open
- update router shim with `useMatch`
- adjust tests for new hooks

## Testing
- `npm test --silent`