### PR TITLE
Add minimal server-rendered landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ supabase functions deploy invite-user
 
 Ensure your Supabase URL and keys are configured in your environment before deploying.
 
+## Public Landing Page
+
+A minimal Node server under `server/` renders a search‑engine friendly landing
+page at `/`. The markup lives in `server/landing.html`. After building the React
+interface you can launch it with:
+
+```bash
+npm run build --prefix web
+node server/server.js
+```
+
+Visit `http://localhost:8080` to view the marketing page. The "Create Account"
+button links to the React application under `/app`.
+
 ## Testing
 
 Vitest is used for frontend unit and integration tests located in `apps/frontend/tests`. Deno's built-in `deno test` runs the edge function tests under `supabase/functions/tests`.

--- a/server/landing.html
+++ b/server/landing.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Faladesk helps your team manage customer conversations across channels." />
+    <title>Faladesk - Customer Support Platform</title>
+  </head>
+  <body>
+    <h1>Faladesk</h1>
+    <p>Multi-channel customer support with AI-powered automation.</p>
+    <a href="/app">Create Account</a>
+  </body>
+</html>

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,51 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 8080;
+const distDir = path.join(__dirname, '..', 'web', 'dist');
+
+function serveFile(filePath, contentType, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+const landingHtml = fs.readFileSync(
+  path.join(__dirname, 'landing.html'),
+  'utf8'
+);
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/' || req.url === '/index.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(landingHtml);
+    return;
+  }
+
+  if (req.url.startsWith('/app')) {
+    const filePath = path.join(distDir, req.url.replace('/app', '') || '/index.html');
+    const ext = path.extname(filePath);
+    const contentType =
+      ext === '.js'
+        ? 'application/javascript'
+        : ext === '.css'
+        ? 'text/css'
+        : 'text/html';
+    serveFile(filePath, contentType, res);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+server.listen(port, () => {
+  console.log(`Landing page server running on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Node http server that serves a landing page
- document how to run the landing page
- separate the landing page HTML into `server/landing.html`

## Testing
- `npm test -- --run` in `web`
- `npm test` in `whatsapp-adapter` *(fails: jest not found)*