### PR TITLE
Add conversation list details

### DIFF
--- a/apps/frontend/tests/components/ConversationList.test.tsx
+++ b/apps/frontend/tests/components/ConversationList.test.tsx
@@ -1,29 +1,53 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import ChatDashboard from '../../../web/src/components/ChatDashboard'
+import ChatDashboard from '../../../../web/src/components/ChatDashboard'
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+vi.mock('../../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: () => ({ messages: [], sendMessage: vi.fn() })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+vi.mock('../../../../web/src/lib/supabase', () => ({
   supabase: {
     from: vi.fn(() => ({
       select: vi.fn(() => ({
-        order: vi.fn(() => Promise.resolve({ data: [
-          { id: '1', customer_name: 'Alice' },
-          { id: '2', customer_name: 'Bob' }
-        ], error: null }))
+        order: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve({
+            data: [
+              {
+                id: '2',
+                customer_name: 'Bob',
+                messages: [
+                  { content: 'yo', sender: 'agent', created_at: '2023-01-03T00:00:00Z' }
+                ]
+              },
+              {
+                id: '1',
+                customer_name: 'Alice',
+                messages: [
+                  { content: 'hello', sender: 'customer', created_at: '2023-01-02T00:00:00Z' }
+                ]
+              }
+            ],
+            error: null
+          }))
+          }))
       }))
-    })
+    }))
   }
 }))
 
 describe('Conversation list', () => {
-  it('renders conversations from supabase', async () => {
+  it('renders conversation details sorted by recent activity', async () => {
     render(<ChatDashboard />)
 
-    expect(await screen.findByText('Alice')).toBeInTheDocument()
-    expect(await screen.findByText('Bob')).toBeInTheDocument()
+    const rows = await screen.findAllByTestId('conversation-row')
+    // Bob is most recent
+    expect(within(rows[0]).getByText('Bob')).toBeInTheDocument()
+    expect(within(rows[0]).getByText('yo')).toBeInTheDocument()
+    expect(within(rows[0]).queryByTestId('unread-indicator')).toBeNull()
+
+    expect(within(rows[1]).getByText('Alice')).toBeInTheDocument()
+    expect(within(rows[1]).getByText('hello')).toBeInTheDocument()
+    expect(within(rows[1]).getByTestId('unread-indicator')).toBeInTheDocument()
   })
 })

--- a/apps/frontend/tests/components/MessageBubble.test.tsx
+++ b/apps/frontend/tests/components/MessageBubble.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import ChatDashboard from '../../../web/src/components/ChatDashboard'
+import ChatDashboard from '../../../../web/src/components/ChatDashboard'
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+vi.mock('../../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: () => ({
     messages: [
       { id: '1', sender: 'customer', content: 'hi', created_at: '' },
@@ -12,7 +12,7 @@ vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
   })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+vi.mock('../../../../web/src/lib/supabase', () => ({
   supabase: { from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
 }))
 

--- a/apps/frontend/tests/components/ReplyBox.test.tsx
+++ b/apps/frontend/tests/components/ReplyBox.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import ChatDashboard from '../../../web/src/components/ChatDashboard'
+import ChatDashboard from '../../../../web/src/components/ChatDashboard'
 
 const sendMock = vi.fn()
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+vi.mock('../../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: () => ({ messages: [], sendMessage: sendMock })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+vi.mock('../../../../web/src/lib/supabase', () => ({
   supabase: { from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
 }))
 

--- a/apps/frontend/tests/e2e/conversation-flow.spec.tsx
+++ b/apps/frontend/tests/e2e/conversation-flow.spec.tsx
@@ -1,19 +1,36 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import ChatDashboard from '../../../web/src/components/ChatDashboard'
+import ChatDashboard from '../../../../web/src/components/ChatDashboard'
 
 const sendMock = vi.fn()
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+vi.mock('../../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: (id: string | null) => ({
     messages: id ? [{ id: 'm1', sender: 'customer', content: 'hi', created_at: '' }] : [],
     sendMessage: sendMock
   })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+vi.mock('../../../../web/src/lib/supabase', () => ({
   supabase: {
-    from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [{ id: 'c1', customer_name: 'Alice' }], error: null })) })) }))
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        order: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve({
+            data: [
+              {
+                id: 'c1',
+                customer_name: 'Alice',
+                messages: [
+                  { content: 'hi', sender: 'customer', created_at: '' }
+                ]
+              }
+            ],
+            error: null
+          }))
+        }))
+      }))
+    }))
   }
 }))
 

--- a/apps/frontend/tests/e2e/login.spec.tsx
+++ b/apps/frontend/tests/e2e/login.spec.tsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import Login from '../../../web/src/components/Login'
+import Login from '../../../../web/src/components/Login'
 
 const signInMock = vi.fn()
-vi.mock('../../../web/src/lib/AuthProvider', () => ({
+vi.mock('../../../../web/src/lib/AuthProvider', () => ({
   useAuth: () => ({ signIn: signInMock })
 }))
 

--- a/apps/frontend/tests/utils/supabaseHooks.test.ts
+++ b/apps/frontend/tests/utils/supabaseHooks.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, act } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
-import { useRealtimeMessages } from '../../../web/src/lib/useRealtimeMessages'
+import { useRealtimeMessages } from '../../../../web/src/lib/useRealtimeMessages'
 
-vi.mock('../../../web/src/lib/supabase', () => {
+vi.mock('../../../../web/src/lib/supabase', () => {
   return {
     supabase: {
       from: vi.fn(() => ({
@@ -30,7 +30,7 @@ describe('useRealtimeMessages', () => {
       await result.current.sendMessage('hello')
     })
 
-    const { supabase } = await import('../../../web/src/lib/supabase')
+    const { supabase } = await import('../../../../web/src/lib/supabase')
     expect((supabase.from as any).mock.calls[0][0]).toBe('messages')
     expect((supabase.from as any).mock.calls[0][1]).toBeUndefined()
     expect((supabase.from as any).mock.lastCall[0]).toBe('messages')

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+web/node_modules

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -14,8 +14,18 @@ export default defineConfig({
       '@gluestack-ui/provider': shim('./shims/gluestack-ui-provider.mjs'),
     }
   },
+  server: {
+    fs: {
+      // allow accessing test files outside the web directory
+      allow: ['..']
+    }
+  },
   test: {
-    include: ['src/**/*.{test,spec}.tsx'],
+    include: ['src/**/*.{test,spec}.tsx', '../apps/frontend/tests/**/*.ts*'],
+    deps: {
+      // ensure external tests resolve dependencies from this package
+      moduleDirectories: [fileURLToPath(new URL('node_modules', import.meta.url))]
+    },
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.ts'


### PR DESCRIPTION
## Summary
- fix relative imports in frontend tests
- include monorepo tests in Vitest config
- allow Vitest to resolve deps across workspace
- symlink root node_modules for test resolution

## Testing
- `npx vitest run` *(fails: module not found and unhandled errors)*