### PR TITLE
Fix shims and add Portuguese login test

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,13 @@ The React agent console lives in [`web/`](./web). To run it locally:
 
 ```bash
 cd web
-npm install
+npm install --legacy-peer-deps  # instala dependências nativas do Gluestack
 npm run dev
 ```
 
 This launches the app with Vite at `http://localhost:5173`.
+When opened in the browser you should see the login form with the button
+labelled **"Entrar"**.
 
 Alternatively, build and run everything with Docker Compose. This will start a
 local Supabase stack alongside the frontend:

--- a/web/shims/README.md
+++ b/web/shims/README.md
@@ -1,0 +1,17 @@
+# Shims
+
+The web frontend relies on several packages that are designed for React Native. These libraries are
+required by `@gluestack-ui/themed`, but they do not work in a browser environment. To allow the
+Vite build and tests to run, lightweight shims are provided in this folder.
+
+## Available Shims
+
+- **react-native** – Stubs common React Native components and utilities.
+- **react-native-svg** – Provides empty SVG components used by icon wrappers.
+- **@gluestack-style/react** – Minimal implementation exposing `AsForwarder` and `styled` along
+  with no-op helpers.
+- **@gluestack-ui/provider** – Simple provider that just renders its children.
+- **react-router-dom** – A tiny router used only for development and tests.
+
+Each shim exports just enough functionality for the app to render in the browser. They are not
+feature complete and should be replaced with the real libraries if native support is required.

--- a/web/shims/empty-module.mjs
+++ b/web/shims/empty-module.mjs
@@ -1,1 +1,2 @@
+// Generic empty module used for optional dependencies.
 export default {}

--- a/web/shims/gluestack-style-react.mjs
+++ b/web/shims/gluestack-style-react.mjs
@@ -1,1 +1,31 @@
-export default {}
+// Shim for `@gluestack-style/react`. Provides the minimal APIs required by
+// `@gluestack-ui/themed` so the project can run in a browser environment.
+import React from 'react'
+
+// Simple forwarder component used by gluestack UI
+export const AsForwarder = React.forwardRef(({ as: Comp = 'div', ...props }, ref) =>
+  React.createElement(Comp, { ref, ...props })
+)
+
+// Extremely light "styled" implementation that simply returns the base component
+export const styled = (Component) =>
+  React.forwardRef((props, ref) => React.createElement(Component, { ref, ...props }))
+
+// No-op providers and helpers
+export const StyledProvider = ({ children }) => <>{children}</>
+export const useStyled = () => ({})
+export const flush = () => {}
+export const createConfig = () => ({})
+export const Theme = {}
+export const useTheme = () => ({})
+
+export default {
+  AsForwarder,
+  styled,
+  StyledProvider,
+  useStyled,
+  flush,
+  createConfig,
+  Theme,
+  useTheme,
+}

--- a/web/shims/gluestack-ui-provider.mjs
+++ b/web/shims/gluestack-ui-provider.mjs
@@ -1,3 +1,4 @@
+// Minimal shim for `@gluestack-ui/provider` which simply renders children.
 export const GluestackUIContextProvider = ({ children }) => children
 export const createProvider = () => ({ children }) => children
 export default { GluestackUIContextProvider, createProvider }

--- a/web/shims/react-native-svg.mjs
+++ b/web/shims/react-native-svg.mjs
@@ -1,3 +1,5 @@
+// Shim for `react-native-svg` used by icon components in Gluestack UI.
+// All exports are empty React components.
 export const Svg = () => null
 export const Polygon = () => null
 export const Rect = () => null

--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -1,3 +1,5 @@
+// Shim for the `react-native` package so the web build doesn't break.
+// Each exported component is a simple stub used by Gluestack UI.
 export const BackHandler = {}
 export const Platform = {}
 export const StatusBar = {}

--- a/web/src/__tests__/LoginPortuguese.test.tsx
+++ b/web/src/__tests__/LoginPortuguese.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import Login from '../components/Login'
+import { I18nProvider } from '../i18n'
+import { vi } from 'vitest'
+
+vi.mock('@gluestack-ui/themed', () => {
+  const React = require('react')
+  return {
+    VStack: (p: any) => <div {...p} />,
+    Input: (p: any) => <div {...p} />,
+    InputField: (p: any) => <input {...p} />,
+    Button: ({ onPress, ...p }: any) => <button onClick={onPress} {...p} />,
+    Text: (p: any) => <span {...p} />,
+  }
+})
+
+vi.mock('../lib/AuthProvider', () => ({
+  useAuth: () => ({ signInWithMagicLink: vi.fn(), signInWithPassword: vi.fn() })
+}))
+
+describe('Login translations', () => {
+  it('renders portuguese text', () => {
+    render(
+      <I18nProvider initialLang="pt-BR">
+        <Login />
+      </I18nProvider>
+    )
+    expect(screen.getByText('Entrar')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- export AsForwarder and other helpers in gluestack-style-react shim
- document all shims and update comments
- tweak README with instructions to install deps and note visible login button
- add regression test ensuring Login shows Portuguese text

## Testing
- `npm run build`
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=key npx vitest run src/__tests__/LoginPortuguese.test.tsx`