### PR TITLE
Fix FlatList export for web shims

### DIFF
--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -18,6 +18,7 @@ export const StyleSheet = { create: () => ({}) }
 export const Dimensions = { get: () => ({}) }
 export const Pressable = () => null
 export const TextInput = () => null
+export const FlatList = () => null
 export const I18nManager = {}
 export const PanResponder = {}
 export const AccessibilityInfo = {
@@ -31,6 +32,7 @@ export default {
   Text,
   Pressable,
   TextInput,
+  FlatList,
   ActivityIndicator,
   Animated,
   StyleSheet,


### PR DESCRIPTION
## Summary
- add a stub for `FlatList` in the `react-native` shim

## Testing
- `npm --prefix web test` *(fails: vitest not found)*
- `deno test -A` in `supabase/functions` *(fails: deno not found)*
