### PR TITLE
Fix useEffect import in ChatDashboard

### DIFF
--- a/web/src/components/ChatDashboard.tsx
+++ b/web/src/components/ChatDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link, Routes, Route } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import ChatView from './ChatView'


### PR DESCRIPTION
## Summary
- fix `ChatDashboard.tsx` by adding `useEffect` to the React import

## Testing
- `npm test --silent` *(fails: Test Files 4 failed | 4 passed)*