### PR TITLE
Add Image stub for React Native shim

### DIFF
--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -5,6 +5,7 @@ export const Platform = {}
 export const StatusBar = {}
 export const View = () => null
 export const Text = () => null
+export const Image = () => null
 export const ActivityIndicator = () => null
 export const Animated = {
   View: View,
@@ -30,6 +31,7 @@ export default {
   StatusBar,
   View,
   Text,
+  Image,
   Pressable,
   TextInput,
   FlatList,


### PR DESCRIPTION
## Summary
- stub `Image` component in the React Native shim
- export `Image` in the default object

## Testing
- `npm run dev` in `web`
- `npm test` in `web` *(fails: ChatDashboard, LoginPortuguese, ChatView)*