### PR TITLE
Add realtime messages mock in ChatView test

### DIFF
--- a/web/src/__tests__/ChatView.test.tsx
+++ b/web/src/__tests__/ChatView.test.tsx
@@ -25,6 +25,20 @@ vi.mock('../lib/supabase', () => ({
   supabase: { from: vi.fn(() => ({ select: vi.fn() })) }
 }))
 
+vi.mock('../lib/useRealtimeMessages', () => ({
+  useRealtimeMessages: () => ({ sendMessage: vi.fn() })
+}))
+
+vi.mock('../components/ConversationThread', () => ({
+  __esModule: true,
+  default: () => <div data-testid="conversation-thread" />
+}))
+
+vi.mock('../components/MessageComposer', () => ({
+  __esModule: true,
+  default: () => <div />
+}))
+
 const updateStatus = vi.fn()
 
 vi.mock('../lib/AuthProvider', () => ({


### PR DESCRIPTION
## Summary
- mock `useRealtimeMessages` in `ChatView.test.tsx`
- stub `ConversationThread` and `MessageComposer` to prevent Supabase calls

## Testing
- `./node_modules/.bin/vitest run src/__tests__/ChatView.test.tsx --silent`