### PR TITLE
Fix react-native shim: export Easing constant

### DIFF
--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -35,6 +35,7 @@ export const Animated = {
     linear: (t) => t
   }
 }
+export const Easing = Animated.Easing
 export const StyleSheet = { create: () => ({}) }
 export const Dimensions = { get: () => ({}) }
 export const Pressable = () => null


### PR DESCRIPTION
## Summary
- update react-native shim to export `Easing` constant

## Testing
- `npm test` *(fails: SUPABASE env values missing)*