### PR TITLE
Add Easing helpers to react-native shim

### DIFF
--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -33,6 +33,32 @@ export const Animated = {
   timing: () => ({ start: () => {} }),
   Easing: {
     linear: (t) => t,
+    ease: (t) => 0.5 * (1 - Math.cos(Math.PI * t)),
+    quad: (t) => t * t,
+    cubic: (t) => t * t * t,
+    poly: (n) => (t) => Math.pow(t, n),
+    sin: (t) => 1 - Math.cos((t * Math.PI) / 2),
+    circle: (t) => 1 - Math.sqrt(1 - t * t),
+    exp: (t) => Math.pow(2, 10 * (t - 1)),
+    back: (s = 1.70158) => (t) => t * t * ((s + 1) * t - s),
+    bounce: (t) => {
+      if (t < 1 / 2.75) return 7.5625 * t * t
+      if (t < 2 / 2.75) {
+        t -= 1.5 / 2.75
+        return 7.5625 * t * t + 0.75
+      }
+      if (t < 2.5 / 2.75) {
+        t -= 2.25 / 2.75
+        return 7.5625 * t * t + 0.9375
+      }
+      t -= 2.625 / 2.75
+      return 7.5625 * t * t + 0.984375
+    },
+    elastic: (b = 1) => (t) =>
+      1 - Math.pow(Math.cos((t * Math.PI) / 2), b),
+    bezier: (_x1, _y1, _x2, _y2) => (t) => t,
+    step0: (t) => (t > 0 ? 1 : 0),
+    step1: (t) => (t >= 1 ? 1 : 0),
     in: (easing) => easing,
     out: (easing) => (t) => 1 - easing(1 - t),
     inOut: (easing) => (t) =>


### PR DESCRIPTION
## Summary
- expand `Animated.Easing` in the web shim to include common helper functions

## Testing
- `node --check web/shims/react-native.mjs`
- `npx tsc --allowJs --checkJs web/shims/react-native.mjs --noEmit`
- `npm run test` *(fails: Tests failed. Watching for file changes...)*
- `/root/.deno/bin/deno test -A` *(fails: Import failed due to network access restrictions)*