### PR TITLE
Add __DEV__ define to Vite and Vitest configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ This launches the app with Vite at `http://localhost:5173`.
 When opened in the browser you should see the login form with the button
 labelled **"Entrar"**.
 
+Vite and Vitest expose a global `__DEV__` constant so components from
+`@gluestack-ui/themed` work correctly in both development and tests.
+
 Alternatively, build and run everything with Docker Compose. This will start a
 local Supabase stack alongside the frontend:
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,7 @@ const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  define: { __DEV__: process.env.NODE_ENV !== 'production' },
   resolve: {
     alias: {
       'react-native': shim('./shims/react-native.mjs'),

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -6,6 +6,7 @@ const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  define: { __DEV__: process.env.NODE_ENV !== 'production' },
   resolve: {
     alias: {
       'react-native': shim('./shims/react-native.mjs'),


### PR DESCRIPTION
## Summary
- expose `__DEV__` in Vite config so gluestack components work
- expose `__DEV__` in Vitest config
- document global `__DEV__` in README

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*