### PR TITLE
Add Keyboard stubs to React Native shim

### DIFF
--- a/web/shims/README.md
+++ b/web/shims/README.md
@@ -6,7 +6,8 @@ Vite build and tests to run, lightweight shims are provided in this folder.
 
 ## Available Shims
 
-- **react-native** – Stubs common React Native components and utilities.
+- **react-native** – Stubs common React Native components and utilities. Basic
+  keyboard event methods like `addListener` and `dismiss` are no-ops.
 - **react-native-svg** – Provides empty SVG components used by icon wrappers.
 - **@gluestack-style/react** – Minimal implementation exposing `AsForwarder` and `styled` along
   with no-op helpers.

--- a/web/shims/react-native.mjs
+++ b/web/shims/react-native.mjs
@@ -12,7 +12,12 @@ export const StatusBar = {}
 export const View = () => null
 export const Text = () => null
 export const Image = () => null
-export const Keyboard = {}
+// Minimal keyboard interface used by some libraries
+export const Keyboard = {
+  addListener: () => ({ remove: () => {} }),
+  removeListener: () => {},
+  dismiss: () => {},
+}
 export const KeyboardAvoidingView = () => null
 export const Linking = {}
 export const Modal = () => null


### PR DESCRIPTION
## Summary
- provide minimal implementations for `Keyboard` in the react-native shim
- document that keyboard event helpers are stubbed

## Testing
- `npm run test` *(fails: Found multiple elements with the text: Hello Alice)*
- `deno test -A` *(fails: `deno` command not found)*