### PR TITLE
Build static Expo web bundle

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const port = process.env.PORT || 8080;
-const distDir = path.join(__dirname, '..', 'web', 'dist');
+const distDir = path.join(__dirname, '..', 'web', 'web-build');
 
 function serveFile(filePath, contentType, res) {
   fs.readFile(filePath, (err, data) => {


### PR DESCRIPTION
## Summary
- install expo-cli in Docker
- export Expo app for web
- update the landing page server to serve from `web-build`

## Testing
- `deno test -A` *(fails: deno not installed)*
- `npm test` in `web` *(fails: missing script)*