### PR TITLE
Update k8s env var names

### DIFF
--- a/k8s/edge-functions-deployment.yaml
+++ b/k8s/edge-functions-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           ports:
             - containerPort: 54321
           env:
-            - name: SUPABASE_URL
+            - name: EXPO_PUBLIC_SUPABASE_URL
               valueFrom:
                 configMapKeyRef:
                   name: faladesk-config

--- a/k8s/email-adapter-deployment.yaml
+++ b/k8s/email-adapter-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: SUPABASE_URL
+            - name: EXPO_PUBLIC_SUPABASE_URL
               valueFrom:
                 configMapKeyRef:
                   name: faladesk-config

--- a/k8s/whatsapp-adapter-deployment.yaml
+++ b/k8s/whatsapp-adapter-deployment.yaml
@@ -35,7 +35,7 @@ spec:
                 secretKeyRef:
                   name: faladesk-secrets
                   key: D360_API_KEY
-            - name: SUPABASE_URL
+            - name: EXPO_PUBLIC_SUPABASE_URL
               valueFrom:
                 configMapKeyRef:
                   name: faladesk-config


### PR DESCRIPTION
## Summary
- switch SUPABASE_URL env var references to `EXPO_PUBLIC_SUPABASE_URL`
- propagate changes across email-adapter, edge-functions and whatsapp-adapter deployments

## Testing
- `npm install --legacy-peer-deps`
- `npm run test -- --run` *(fails: Missing script 'test')*
- `deno test -A` *(fails: command not found)*