### PR TITLE
Switch frontend tests to jest-expo

### DIFF
--- a/apps/frontend/tests/components/ConversationList.test.tsx
+++ b/apps/frontend/tests/components/ConversationList.test.tsx
@@ -1,16 +1,16 @@
-import { render, screen } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import ChatDashboard from '../../../web/src/components/ChatDashboard'
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
-  useRealtimeMessages: () => ({ messages: [], sendMessage: vi.fn() })
+jest.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+  useRealtimeMessages: () => ({ messages: [], sendMessage: jest.fn() })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+jest.mock('../../../web/src/lib/supabase', () => ({
   supabase: {
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        order: vi.fn(() => Promise.resolve({ data: [
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        order: jest.fn(() => Promise.resolve({ data: [
           { id: '1', customer_name: 'Alice' },
           { id: '2', customer_name: 'Bob' }
         ], error: null }))
@@ -23,7 +23,7 @@ describe('Conversation list', () => {
   it('renders conversations from supabase', async () => {
     render(<ChatDashboard />)
 
-    expect(await screen.findByText('Alice')).toBeInTheDocument()
-    expect(await screen.findByText('Bob')).toBeInTheDocument()
+    expect(await screen.findByText('Alice')).toBeTruthy()
+    expect(await screen.findByText('Bob')).toBeTruthy()
   })
 })

--- a/apps/frontend/tests/components/MessageBubble.test.tsx
+++ b/apps/frontend/tests/components/MessageBubble.test.tsx
@@ -1,26 +1,26 @@
-import { render, screen } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import ChatDashboard from '../../../web/src/components/ChatDashboard'
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+jest.mock('../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: () => ({
     messages: [
       { id: '1', sender: 'customer', content: 'hi', created_at: '' },
       { id: '2', sender: 'agent', content: 'hello', created_at: '' }
     ],
-    sendMessage: vi.fn()
+    sendMessage: jest.fn()
   })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
-  supabase: { from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
+jest.mock('../../../web/src/lib/supabase', () => ({
+  supabase: { from: jest.fn(() => ({ select: jest.fn(() => ({ order: jest.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
 }))
 
 describe('MessageBubble', () => {
   it('differentiates sender roles', async () => {
     render(<ChatDashboard />)
     const rows = await screen.findAllByTestId('message-row')
-    expect(rows[0].style.justifyContent).toBe('flex-start')
-    expect(rows[1].style.justifyContent).toBe('flex-end')
+    expect(rows[0]).toHaveStyle({ justifyContent: 'flex-start' })
+    expect(rows[1]).toHaveStyle({ justifyContent: 'flex-end' })
   })
 })

--- a/apps/frontend/tests/components/ReplyBox.test.tsx
+++ b/apps/frontend/tests/components/ReplyBox.test.tsx
@@ -1,24 +1,24 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import ChatDashboard from '../../../web/src/components/ChatDashboard'
 
-const sendMock = vi.fn()
+const sendMock = jest.fn()
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+jest.mock('../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: () => ({ messages: [], sendMessage: sendMock })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
-  supabase: { from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
+jest.mock('../../../web/src/lib/supabase', () => ({
+  supabase: { from: jest.fn(() => ({ select: jest.fn(() => ({ order: jest.fn(() => Promise.resolve({ data: [], error: null })) })) })) }
 }))
 
 describe('ReplyBox', () => {
   it('calls sendMessage function and clears input', async () => {
     render(<ChatDashboard />)
     const input = await screen.findByTestId('reply-box')
-    fireEvent.change(input, { target: { value: 'hello' } })
-    fireEvent.submit(input.closest('form') as HTMLFormElement)
+    fireEvent.changeText(input, 'hello')
+    fireEvent(input, 'submitEditing')
     expect(sendMock).toHaveBeenCalledWith('hello')
-    expect((input as HTMLInputElement).value).toBe('')
+    expect(input.props.value).toBe('')
   })
 })

--- a/apps/frontend/tests/e2e/conversation-flow.spec.ts
+++ b/apps/frontend/tests/e2e/conversation-flow.spec.ts
@@ -1,32 +1,32 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import ChatDashboard from '../../../web/src/components/ChatDashboard'
 
-const sendMock = vi.fn()
+const sendMock = jest.fn()
 
-vi.mock('../../../web/src/lib/useRealtimeMessages', () => ({
+jest.mock('../../../web/src/lib/useRealtimeMessages', () => ({
   useRealtimeMessages: (id: string | null) => ({
     messages: id ? [{ id: 'm1', sender: 'customer', content: 'hi', created_at: '' }] : [],
     sendMessage: sendMock
   })
 }))
 
-vi.mock('../../../web/src/lib/supabase', () => ({
+jest.mock('../../../web/src/lib/supabase', () => ({
   supabase: {
-    from: vi.fn(() => ({ select: vi.fn(() => ({ order: vi.fn(() => Promise.resolve({ data: [{ id: 'c1', customer_name: 'Alice' }], error: null })) })) }))
+    from: jest.fn(() => ({ select: jest.fn(() => ({ order: jest.fn(() => Promise.resolve({ data: [{ id: 'c1', customer_name: 'Alice' }], error: null })) })) }))
   }
 }))
 
 describe('Conversation flow', () => {
   it('open conversation and reply', async () => {
     render(<ChatDashboard />)
-    fireEvent.click(await screen.findByText('Alice'))
+    fireEvent.press(await screen.findByText('Alice'))
     const msg = await screen.findByText('hi')
-    expect(msg).toBeInTheDocument()
+    expect(msg).toBeTruthy()
 
     const input = await screen.findByTestId('reply-box')
-    fireEvent.change(input, { target: { value: 'hello' } })
-    fireEvent.submit(input.closest('form') as HTMLFormElement)
+    fireEvent.changeText(input, 'hello')
+    fireEvent(input, 'submitEditing')
     expect(sendMock).toHaveBeenCalledWith('hello')
   })
 })

--- a/apps/frontend/tests/e2e/login.spec.ts
+++ b/apps/frontend/tests/e2e/login.spec.ts
@@ -1,10 +1,10 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import Login from '../../../web/src/components/Login'
 
-const passwordLoginMock = vi.fn()
-const magicLoginMock = vi.fn()
-vi.mock('../../../web/src/lib/AuthProvider', () => ({
+const passwordLoginMock = jest.fn()
+const magicLoginMock = jest.fn()
+jest.mock('../../../web/src/lib/AuthProvider', () => ({
   useAuth: () => ({
     signInWithPassword: passwordLoginMock,
     signInWithMagicLink: magicLoginMock
@@ -16,17 +16,17 @@ describe('Login flow', () => {
     render(<Login />)
     const emailInput = screen.getByPlaceholderText('you@example.com')
     const passInput = screen.getByPlaceholderText('Password')
-    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
-    fireEvent.change(passInput, { target: { value: 'secret' } })
-    fireEvent.submit(screen.getByTestId('login-form'))
+    fireEvent.changeText(emailInput, 'user@example.com')
+    fireEvent.changeText(passInput, 'secret')
+    fireEvent.press(screen.getByTestId('login-form'))
     expect(passwordLoginMock).toHaveBeenCalledWith('user@example.com', 'secret')
   })
 
   it('user can request magic link', async () => {
     render(<Login />)
     const emailInput = screen.getByPlaceholderText('you@example.com')
-    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
-    fireEvent.click(screen.getByText('Send Magic Link'))
+    fireEvent.changeText(emailInput, 'user@example.com')
+    fireEvent.press(screen.getByText('Send Magic Link'))
     expect(magicLoginMock).toHaveBeenCalledWith('user@example.com')
   })
 })

--- a/apps/frontend/tests/utils/supabaseHooks.test.ts
+++ b/apps/frontend/tests/utils/supabaseHooks.test.ts
@@ -1,29 +1,29 @@
-import { renderHook, act } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react-native'
+import { describe, it, expect, jest } from '@jest/globals'
 import { useRealtimeMessages } from '../../../web/src/lib/useRealtimeMessages'
 import { useAgentPresence } from '../../../web/src/lib/useAgentPresence'
 
-vi.mock('../../../web/src/lib/supabase', () => {
-  const fromMock = vi.fn((table: string) => {
+jest.mock('../../../web/src/lib/supabase', () => {
+  const fromMock = jest.fn((table: string) => {
     if (table === 'messages') {
       return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            order: vi.fn(() => Promise.resolve({ data: [], error: null }))
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({ data: [], error: null }))
           }))
         })),
-        insert: vi.fn()
+        insert: jest.fn()
       }
     }
     if (table === 'users') {
       return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            single: vi.fn(() => Promise.resolve({ data: { status: 'offline' } }))
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            single: jest.fn(() => Promise.resolve({ data: { status: 'offline' } }))
           }))
         })),
-        update: vi.fn(() => ({
-          eq: vi.fn(() => Promise.resolve({ data: {} }))
+        update: jest.fn(() => ({
+          eq: jest.fn(() => Promise.resolve({ data: {} }))
         }))
       }
     }
@@ -33,11 +33,11 @@ vi.mock('../../../web/src/lib/supabase', () => {
   return {
     supabase: {
       from: fromMock,
-      channel: vi.fn(() => ({
-        on: vi.fn().mockReturnThis(),
-        subscribe: vi.fn().mockReturnThis()
+      channel: jest.fn(() => ({
+        on: jest.fn().mockReturnThis(),
+        subscribe: jest.fn().mockReturnThis()
       })),
-      removeChannel: vi.fn()
+      removeChannel: jest.fn()
     }
   }
 })

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['./jest.setup.ts'],
+  testMatch: ['<rootDir>/../apps/frontend/tests/**/*.(test|spec).tsx?'],
+};

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -1,0 +1,46 @@
+import '@testing-library/jest-native/extend-expect';
+
+jest.mock('react-native', () => ({
+  View: () => null,
+  Text: () => null,
+  Pressable: () => null,
+  TextInput: () => null,
+  ActivityIndicator: () => null,
+  StyleSheet: { create: () => ({}) },
+  BackHandler: {},
+  Platform: {},
+  StatusBar: {},
+  Dimensions: { get: () => ({}) },
+  I18nManager: {},
+  PanResponder: {},
+  default: {},
+}));
+
+jest.mock('react-native-svg', () => {
+  const Stub = () => null;
+  return {
+    Svg: Stub,
+    Polygon: Stub,
+    Rect: Stub,
+    Circle: Stub,
+    Ellipse: Stub,
+    Line: Stub,
+    Polyline: Stub,
+    Path: Stub,
+    Text: Stub,
+    TSpan: Stub,
+    TextPath: Stub,
+    G: Stub,
+    ClipPath: Stub,
+    LinearGradient: Stub,
+    RadialGradient: Stub,
+    default: Stub,
+  };
+});
+
+jest.mock('@gluestack-style/react', () => ({}));
+
+jest.mock('@gluestack-ui/provider', () => ({
+  GluestackUIContextProvider: ({ children }) => children,
+  createProvider: () => ({ children }) => children,
+}));

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "expo": "^49.0.0",
@@ -23,6 +24,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "jest-expo": "^49.0.0",
+    "@testing-library/react-native": "^12.1.5",
+    "@testing-library/jest-native": "^5.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `jest-expo` and testing libraries to `web/package.json`
- create Jest config and setup mocking native modules
- rewrite frontend tests for React Native and jest

## Testing
- `npm test` *(fails: jest not found)*