### PR TITLE
Fix path for Expo export dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN npx expo export --platform web
 
 # Production stage
 FROM nginx:1.25-alpine
-COPY --from=build /app/web/web-build /usr/share/nginx/html
+COPY --from=build /app/web/dist /usr/share/nginx/html
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ docker compose up --build
 
 Once the containers are running Expo serves the app on
 `http://localhost:8081`. Supabase exposes its services on ports `54321`, `54322`
-and `8000`. The production `Dockerfile` runs `expo export` to build the
-static web assets served by Nginx.
+and `8000`. The production `Dockerfile` runs `expo export` to build the static
+web assets under `web/dist`, which Nginx serves.
 
 ### Deploying edge functions
 
@@ -201,7 +201,7 @@ interface you can launch it with:
 
 ```bash
 cd web
-npx expo export --platform web
+npx expo export --platform web  # outputs to dist/
 cd ..
 node server/server.js
 ```

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const port = process.env.PORT || 8080;
-const distDir = path.join(__dirname, '..', 'web', 'web-build');
+const distDir = path.join(__dirname, '..', 'web', 'dist');
 
 function serveFile(filePath, contentType, res) {
   fs.readFile(filePath, (err, data) => {


### PR DESCRIPTION
## Summary
- point server and Dockerfile to the Expo export `dist` directory
- document the new location in README

## Testing
- `npm test` *(fails: Cannot find module 'jest/package.json')*
- `deno test -A` *(fails: deno: command not found)*