### PR TITLE
Update Dockerfiles to use yarn lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM node:18-alpine AS build
 WORKDIR /app
 
 # Copy frontend source
-COPY web/package.json ./web/package.json
-COPY web/package-lock.json ./web/package-lock.json
+COPY web/package.json web/yarn.lock ./web/
 WORKDIR /app/web
 RUN npm install -g expo-cli
-RUN yanr install
+RUN yarn install --legacy-peer-deps
 COPY web .
 
 # Pass Supabase env vars as build args

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@ WORKDIR /app/web
 RUN npm install -g expo-cli
 
 # Install project dependencies
-COPY ./web/package.json ./web/package-lock.json* ./
+COPY ./web/package.json ./web/yarn.lock ./
 RUN yarn install --legacy-peer-deps
 
 # Copy all project sources


### PR DESCRIPTION
## Summary
- copy `web/package.json` and `web/yarn.lock` during Docker build
- use `yarn install --legacy-peer-deps`

## Testing
- `yarn install --immutable` *(fails: unable to download packages)*
- `yarn test` *(fails: package not present in lockfile)*