### PR TITLE
Start expo offline by default

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "main": "index.js",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --offline",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Summary
- run `expo start` in offline mode by default

## Testing
- `npx expo start --offline` *(fails: waiting for local server)*
- `npm test` *(fails: Cannot find module 'jest/package.json')*