### PR TITLE
Replace navigation hooks with React Router

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,7 @@ export default function App() {
       <Routes>
         <Route path="/create-company" element={<CreateCompany />} />
         <Route path="/invite" element={<InviteTeammate />} />
-        <Route path="/*" element={<ChatDashboard />} />
+        <Route path="/chat/*" element={<ChatDashboard />} />
         <Route path="*" element={<DashboardRedirect />} />
       </Routes>
     </BrowserRouter>

--- a/web/src/components/ChatDashboard.tsx
+++ b/web/src/components/ChatDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { View, Text, TouchableOpacity, ScrollView, Button } from 'react-native'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import SettingsModal from './SettingsModal'
 import { useI18n } from '../i18n'
@@ -14,7 +14,7 @@ export default function ChatDashboard() {
   const [showSettings, setShowSettings] = useState(false)
   const { t } = useI18n()
   const [conversations, setConversations] = useState<Conversation[]>([])
-  const navigation = useNavigation()
+  const navigate = useNavigate()
 
   useEffect(() => {
     const fetchConversations = async () => {
@@ -32,11 +32,11 @@ export default function ChatDashboard() {
       <Button title={t('settings')} onPress={() => setShowSettings(true)} />
       {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
       <ScrollView style={{ flex: 1 }}>
-        <TouchableOpacity onPress={() => navigation.navigate('Invite' as never)} style={{ padding: 10, borderBottomWidth: 1, borderColor: '#f0f0f0' }}>
+        <TouchableOpacity onPress={() => navigate('/invite')} style={{ padding: 10, borderBottomWidth: 1, borderColor: '#f0f0f0' }}>
           <Text>{t('invite_teammate')}</Text>
         </TouchableOpacity>
         {conversations.map(c => (
-          <TouchableOpacity key={c.id} onPress={() => navigation.navigate('ChatView' as never, { chatId: c.id })} style={{ padding: 10, borderBottomWidth: 1, borderColor: '#f0f0f0' }}>
+          <TouchableOpacity key={c.id} onPress={() => navigate(`/chat/${c.id}`)} style={{ padding: 10, borderBottomWidth: 1, borderColor: '#f0f0f0' }}>
             <Text>{c.customer_name}</Text>
           </TouchableOpacity>
         ))}

--- a/web/src/components/CreateCompany.tsx
+++ b/web/src/components/CreateCompany.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { VStack, Input, InputField, Button, Text } from '@gluestack-ui/themed'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../lib/AuthProvider'
 import { useI18n } from '../i18n'
 
 export default function CreateCompany() {
   const { session } = useAuth()
-  const navigation = useNavigation()
+  const navigate = useNavigate()
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
   const [userName, setUserName] = useState('')
@@ -39,7 +39,7 @@ export default function CreateCompany() {
     if (userError) {
       setError(userError.message)
     } else {
-      navigation.navigate('Chat' as never)
+      navigate('/chat')
     }
   }
 

--- a/web/src/components/DashboardRedirect.tsx
+++ b/web/src/components/DashboardRedirect.tsx
@@ -1,17 +1,17 @@
 import { useEffect } from 'react'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigate } from 'react-router-dom'
 import { useUserOrganization } from '../lib/useUserOrganization'
 
 export default function DashboardRedirect() {
   const { user, loading } = useUserOrganization()
-  const navigation = useNavigation()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (!loading) {
       if (!user) {
-        navigation.navigate('CreateCompany' as never)
+        navigate('/create-company')
       } else {
-        navigation.navigate('Chat' as never)
+        navigate('/chat')
       }
     }
   }, [user, loading])


### PR DESCRIPTION
## Summary
- use `useNavigate` from `react-router-dom` in CreateCompany, ChatDashboard and DashboardRedirect
- update App routes so ChatDashboard lives under `/chat/*`

## Testing
- `npm run test` *(fails: Cannot find module 'jest/package.json')*