### PR TITLE
Use i18n placeholder in MessageComposer

### DIFF
--- a/web/src/components/MessageComposer.tsx
+++ b/web/src/components/MessageComposer.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { View, TextInput, Button } from 'react-native'
+import { useI18n } from '../i18n'
 
 interface Props {
   onSend: (content: string) => Promise<void> | void
@@ -7,6 +8,7 @@ interface Props {
 
 export default function MessageComposer({ onSend }: Props) {
   const [input, setInput] = useState('')
+  const { t } = useI18n()
 
   const handleSend = async () => {
     if (!input.trim()) return
@@ -20,7 +22,7 @@ export default function MessageComposer({ onSend }: Props) {
         style={{ flex: 1, borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 }}
         value={input}
         onChangeText={setInput}
-        placeholder="Type a message..."
+        placeholder={t('type_message')}
       />
       <Button title="Send" onPress={handleSend} />
     </View>


### PR DESCRIPTION
## Summary
- import `useI18n` in MessageComposer
- use translation key `type_message` for placeholder text

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest/package.json')*