### PR TITLE
Add webpack config to transpile gluestack-ui

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,0 +1,27 @@
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const path = require('path');
+
+module.exports = async (env, argv) => {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+
+  // Locate babel-loader and extend its include paths
+  const rules = config.module.rules.flatMap((rule) => rule.oneOf || [rule]);
+  const babelLoader = rules.find((rule) => {
+    const use = rule.use;
+    if (!use) return false;
+    if (Array.isArray(use)) {
+      return use.some((u) => u.loader && u.loader.includes('babel-loader'));
+    }
+    return use.loader && use.loader.includes('babel-loader');
+  });
+
+  if (babelLoader) {
+    babelLoader.include = [
+      babelLoader.include,
+      // Transpile all gluestack-ui packages
+      path.join(__dirname, 'node_modules/@gluestack-ui'),
+    ];
+  }
+
+  return config;
+};


### PR DESCRIPTION
## Summary
- create `web/webpack.config.js` based on Expo's default config
- ensure babel-loader transpiles `@gluestack-ui` modules

## Testing
- `npm run web` *(fails: FetchError due to network restriction)*
- `npm run test` *(fails: Cannot find module 'jest/package.json')*